### PR TITLE
Add (Non)NullishKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ or `ts-essentials@2` instead. If you use any [functions](https://github.com/krzk
   - [Merge](#Merge)
   - [MarkRequired](#MarkRequired)
   - [MarkOptional](#MarkOptional)
-  - [ReadonlyKeys](#ReadonlyKeys)
-  - [WritableKeys](#WritableKeys)
-  - [OptionalKeys](#OptionalKeys)
-  - [RequiredKeys](#RequiredKeys)
+  - [Key filter types](#Key-filter-types)
+    - ReadonlyKeys
+    - WritableKeys
+    - OptionalKeys
+    - RequiredKeys
+    - (Non)NullishKeys
   - [UnionToIntersection](#UnionToIntersection)
   - [Opaque types](#Opaque-types)
   - [Tuple constraint](#Tuple-constraint)
@@ -121,12 +123,12 @@ const port: number = configDict["PORT"];
 
 ### Deep\* wrapper types
 
-- DeepPartial
-- DeepRequired
-- DeepReadonly
-- DeepNonNullable
-- DeepNullable
-- DeepUndefinable
+- `DeepPartial`
+- `DeepRequired`
+- `DeepReadonly`
+- `DeepNonNullable`
+- `DeepNullable`
+- `DeepUndefinable`
 
 _keywords: recursive, nested, optional_
 
@@ -512,64 +514,41 @@ type UserWithoutPassword = MarkOptional<User, "password">;
 // }
 ```
 
-### ReadonlyKeys
+### Key filter types
 
-Gets keys of an object which are readonly.
+Get different subsets of an object's keys:
 
-```typescript
-type T = {
-  readonly a: number;
-  b: string;
-};
-type Result = ReadonlyKeys<T>;
-// Result:
-// "a"
-```
-
-### WritableKeys
-
-Gets keys of an object which are writable.
+- `ReadonlyKeys`: keys which are readonly.
+- `WritableKeys`: keys which are writable.
+- `OptionalKeys`: keys which are optional.
+- `RequiredKeys`: keys which are required.
+- `NullishKeys`: keys that are optional or can have nullish values.
+- `NonNullishKeys`: keys that are required to have a non-nullish value.
 
 ```typescript
 type T = {
   readonly a: number;
   b: string;
 };
-type Result = WritableKeys<T>;
-// Result:
-// "b"
-```
+type TReadonlyKeys = ReadonlyKeys<T>;
+// TReadonlyKeys: "a"
+type TWritableKeys = WritableKeys<T>;
+// TWritableKeys: "b"
 
-### OptionalKeys
-
-Gets keys of an object which are optional.
-
-```typescript
-type T = {
+type O = {
   a: number;
   b?: string;
   c: string | undefined;
-  d?: string;
+  d: string | null;
 };
-type Result = OptionalKeys<T>;
-// Result:
-// "b" | "d"
-```
-
-### RequiredKeys
-
-Gets keys of an object which are required.
-
-```typescript
-type T = {
-  a: number;
-  b?: string;
-  c: string | undefined;
-  d?: string;
-};
-type Result = RequiredKeys<T>;
-// Result:
-// "a" | "c"
+type OOptionalKeys = OptionalKeys<O>;
+// OOptionalKeys: "b"
+type ORequiredKeys = RequiredKeys<O>;
+// ORequiredKeysResult: "a" | "c" | "d"
+type ONullishKeys = NullishKeys<O>;
+// ONullishKeys: "b" | "c" | "d"
+type ONonNullishKeys = NonNullishKeys<O>;
+// ONonNullishKeys: "a"
 ```
 
 ### UnionToIntersection

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -202,6 +202,14 @@ export type OptionalKeys<T> = {
 /** Gets keys of an object which are required */
 export type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
 
+/** Gets keys of an object that can have a nullish value */
+export type NullishKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K] ? K : null extends T[K] ? K : never;
+}[keyof T];
+
+/** Gets keys of an object that can't have a nullish value */
+export type NonNullishKeys<T> = Exclude<keyof T, NullishKeys<T>>;
+
 /** Recursively omit deep properties */
 // explicitly mentioning optional properties, to work around TS making them required
 // see https://github.com/krzkaczor/ts-essentials/issues/118

--- a/test/index.ts
+++ b/test/index.ts
@@ -39,6 +39,8 @@ import {
   AsyncOrSync,
   Awaited,
   Newable,
+  NullishKeys,
+  NonNullishKeys,
 } from "../lib";
 
 function testDictionary() {
@@ -328,6 +330,22 @@ function testRequiredKeys() {
   type Actual = RequiredKeys<Input>;
 
   type Test = Assert<IsExact<Expected, Actual>>;
+}
+
+function testNullishKeys() {
+  type Input = {
+    req: string;
+    opt?: string;
+    undef: string | undefined;
+    nullable: string | null;
+    both?: string | null;
+  };
+
+  type ActualNullishKeys = NullishKeys<Input>;
+  type TestNullishKeys = Assert<IsExact<"opt" | "undef" | "nullable" | "both", ActualNullishKeys>>;
+
+  type ActualNonNullishKeys = NonNullishKeys<Input>;
+  type TestNonNullishKeys = Assert<IsExact<"req", ActualNonNullishKeys>>;
 }
 
 function testDeepOmit() {


### PR DESCRIPTION
Added a type to extract keys that can have nullish values.

Useful for example in one of my util functions:

```typescript
export function pickDefinedEntries<T extends AnyObject>(
    obj: T,
): MarkOptional<T, NullishKeys<T>> {
    // ...
}
```
