### PR TITLE
docs: type error in DeepPick/DeepOmit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ type TeacherSimple = DeepOmit<
     gender: never;
     students: {
       score: never;
-    };
+    }[];
   }
 >;
 
@@ -571,7 +571,7 @@ type TeacherSimple = DeepPick<
     gender: never;
     students: {
       score: never;
-    };
+    }[];
   }
 >;
 


### PR DESCRIPTION
miss `[]` in DeepPick/DeepOmit example

before
![image](https://user-images.githubusercontent.com/23382699/155933349-c3262f9c-f1b9-4196-b38d-d79252ef1f15.png)

this pr
![image](https://user-images.githubusercontent.com/23382699/155933607-9b49134c-a0bb-451d-a450-3a2c7e3f0cf2.png)

