### PR TITLE
add PredicateType and PredicateFunction interfaces and full set of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,24 @@ assert(anything instanceof String, "anything has to be a string!");
 // from now on `anything` is string
 ```
 
+### PredicateType
+_keywords: narrow, guard, validate_
+
+Works just like [`ReturnType`](https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype) but will return the [predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) associated with the function instead. This is particularly useful if you need to chain guards to narrow broader types.
+
+```typescript
+// Without PredicateType you can never use a set of functions like this together; how can you resolve ???
+// You would need a specific instance of isArrayOf for each type you want to narrow
+const isArrayOf = (thing: unknown, validator: (...x: any[]) => boolean): thing is ???[] => {
+  return Array.isArray(thing) && thing.every(validator)
+}
+
+// With PredicateType you can pull the predicate of the validator into the higher level guard
+const isArrayOf = <T extends (...x: any[]) => boolean>(thing: unknown, validator: T): thing is Array<PredicateType<T>> => {
+  return Array.isArray(thing) && thing.every(validator)
+}
+```
+
 ### Exact
 
 _keywords: same, equals, equality_

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -475,3 +475,15 @@ export type Tail<T extends AnyArray> = T["length"] extends 0
   : never;
 
 export type Exact<T, SHAPE> = T extends SHAPE ? (Exclude<keyof T, keyof SHAPE> extends never ? T : never) : never;
+
+/**
+ * Basic interface for guarded functions that use [predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates)
+ */
+export type PredicateFunction = (x: any, ..._z: any[]) => x is any;
+
+/**
+ * Extracts the [predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) of a guarded function
+ */
+export type PredicateType<T extends PredicateFunction> = T extends (target: any, ...rest: any[]) => target is infer P
+  ? P
+  : never;

--- a/test/predicate-type.ts
+++ b/test/predicate-type.ts
@@ -1,0 +1,58 @@
+import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
+import { PredicateType } from "../lib/types";
+
+function testPredicateType() {
+  type GeneralCases = [
+    // simple type guards
+    Assert<IsExact<PredicateType<(a: unknown) => a is false>, false>>,
+    Assert<IsExact<PredicateType<(a: unknown) => a is true>, true>>,
+    Assert<IsExact<PredicateType<(a: unknown) => a is boolean>, boolean>>,
+    Assert<IsExact<PredicateType<(a: unknown) => a is any>, any>>,
+    Assert<IsExact<PredicateType<(a: unknown) => a is unknown>, unknown>>,
+    Assert<IsExact<PredicateType<(a: unknown) => a is [1, 2, 3]>, [1, 2, 3]>>,
+    Assert<IsExact<PredicateType<(a: unknown) => a is never>, never>>,
+    // simple type guards with complex predicates
+    Assert<IsExact<PredicateType<(a: unknown) => a is 1 | 2>, 1 | 2>>,
+    Assert<IsExact<PredicateType<(a: { z: string }) => a is typeof a & { y: boolean }>, { z: string; y: boolean }>>,
+    // type guard with predicate first and additional arguments
+    Assert<IsExact<PredicateType<(a: unknown, _z: any) => a is string[]>, string[]>>,
+    // functions without predicate is an error
+    // @ts-expect-error
+    Assert<IsExact<PredicateType<() => false>, never>>,
+    // @ts-expect-error
+    Assert<IsExact<PredicateType<() => true>, never>>,
+    // @ts-expect-error
+    Assert<IsExact<PredicateType<() => boolean>, never>>,
+    // Wrong argument format is an error
+    // @ts-expect-error
+    Assert<IsExact<PredicateType<(thing: unknown, other: unknown) => other is string>, never>>,
+    // Assertions are not predicates and will error
+    // @ts-expect-error
+    Assert<IsExact<PredicateType<(thing: unknown) => asserts thing is false>, never>>,
+  ];
+
+  // Chainability tests
+  const chainingTestArray = ["some", 1, true, 2, "u"];
+  const isArrayOf = <T extends (x: any, ..._z: any[]) => x is any>(
+    thing: unknown,
+    validator: T,
+  ): thing is Array<PredicateType<T>> => {
+    return Array.isArray(thing) && thing.every(validator);
+  };
+
+  const isBoolean = (a: unknown): a is boolean => typeof a === "boolean";
+  const isNumber = (a: unknown): a is number => typeof a === "number";
+  const isString = (a: unknown): a is string => typeof a === "string";
+
+  if (isArrayOf(chainingTestArray, isBoolean)) {
+    type cases = [Assert<IsExact<typeof chainingTestArray, boolean[]>>];
+  }
+
+  if (isArrayOf(chainingTestArray, isNumber)) {
+    type cases = [Assert<IsExact<typeof chainingTestArray, number[]>>];
+  }
+
+  if (isArrayOf(chainingTestArray, isString)) {
+    type cases = [Assert<IsExact<typeof chainingTestArray, string[]>>];
+  }
+}

--- a/test/predicate-type.ts
+++ b/test/predicate-type.ts
@@ -1,5 +1,5 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
-import { PredicateType } from "../lib/types";
+import { PredicateFunction, PredicateType } from "../lib/types";
 
 function testPredicateType() {
   type GeneralCases = [
@@ -33,7 +33,7 @@ function testPredicateType() {
 
   // Chainability tests
   const chainingTestArray = ["some", 1, true, 2, "u"];
-  const isArrayOf = <T extends (x: any, ..._z: any[]) => x is any>(
+  const isArrayOf = <T extends PredicateFunction>(
     thing: unknown,
     validator: T,
   ): thing is Array<PredicateType<T>> => {

--- a/test/predicate-type.ts
+++ b/test/predicate-type.ts
@@ -33,10 +33,7 @@ function testPredicateType() {
 
   // Chainability tests
   const chainingTestArray = ["some", 1, true, 2, "u"];
-  const isArrayOf = <T extends PredicateFunction>(
-    thing: unknown,
-    validator: T,
-  ): thing is Array<PredicateType<T>> => {
+  const isArrayOf = <T extends PredicateFunction>(thing: unknown, validator: T): thing is Array<PredicateType<T>> => {
     return Array.isArray(thing) && thing.every(validator);
   };
 


### PR DESCRIPTION
Fixes #253

1. Adds type called `PredicateType` to support snagging predicates off of guarded functions
2. Adds utility type called `PredicateFunction` to let folks duplicate the interface for things like the `isArrayOf` [example in the tests](https://github.com/ts-essentials/ts-essentials/blob/3fddc463985967e6084a9a7e0d5009b15d6ef793/test/predicate-type.ts#L36). I left it undocumented on the readme because this doesn't seem like a normal thing to need, but it is easily discovered