### PR TITLE
fix: DeepReadonly for a union with an array of itself (#306)

### DIFF
--- a/.changeset/moody-oranges-care.md
+++ b/.changeset/moody-oranges-care.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `DeepReadonly` for a union with an array of itself

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -167,6 +167,8 @@ export type DeepReadonly<T> = T extends Builtin
   ? WeakSet<DeepReadonly<U>>
   : T extends Promise<infer U>
   ? Promise<DeepReadonly<U>>
+  : T extends AnyArray<infer U>
+  ? readonly DeepReadonly<U>[] 
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : IsUnknown<T> extends true

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -168,7 +168,9 @@ export type DeepReadonly<T> = T extends Builtin
   : T extends Promise<infer U>
   ? Promise<DeepReadonly<U>>
   : T extends AnyArray<infer U>
-  ? readonly DeepReadonly<U>[]
+  ? T extends IsTuple<T>
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : ReadonlyArray<DeepReadonly<U>>
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : IsUnknown<T> extends true

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -168,7 +168,7 @@ export type DeepReadonly<T> = T extends Builtin
   : T extends Promise<infer U>
   ? Promise<DeepReadonly<U>>
   : T extends AnyArray<infer U>
-  ? readonly DeepReadonly<U>[] 
+  ? readonly DeepReadonly<U>[]
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : IsUnknown<T> extends true

--- a/test/index.ts
+++ b/test/index.ts
@@ -316,11 +316,11 @@ function testDeepReadonly() {
 
   // Build-time test to ensure the fix for
   // https://github.com/ts-essentials/ts-essentials/pull/310
-  // because IsExact<> is unable to text it. 
+  // because IsExact<> is unable to text it.
   {
     type TestUnion = { value: string } | TestUnion[];
     type ReadonlyTestUnion = { readonly value: string } | readonly ReadonlyTestUnion[];
-  
+
     const a: DeepReadonly<TestUnion> = [];
     const b: ReadonlyTestUnion = a;
   }

--- a/test/index.ts
+++ b/test/index.ts
@@ -302,6 +302,7 @@ function testDeepReadonly() {
     Assert<IsExact<DeepReadonly<[1, 2, 3]>, readonly [1, 2, 3]>>,
     Assert<IsExact<DeepReadonly<readonly number[]>, readonly number[]>>,
     Assert<IsExact<DeepReadonly<Array<number>>, ReadonlyArray<number>>>,
+    Assert<IsExact<DeepReadonly<Array<TestUnion>>, ReadonlyTestUnion>>,
     Assert<IsExact<DeepReadonly<Promise<number>>, Promise<number>>>,
     Assert<IsExact<DeepReadonly<{ a: 1; b: 2; c: 3 }>, { a: 1; b: 2; c: 3 }>>,
     Assert<IsExact<DeepReadonly<{ foo: () => void }>, { foo: () => void }>>,
@@ -313,6 +314,9 @@ function testDeepReadonly() {
     >,
     Assert<IsExact<DeepReadonly<ComplexNestedRequired>, ComplexNestedReadonly>>,
   ];
+
+  type TestUnion = { value: string } | TestUnion[];
+  type ReadonlyTestUnion = { readonly value: string } | readonly TestUnion[];
 
   // Build-time test to ensure the fix for
   // https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.

--- a/test/index.ts
+++ b/test/index.ts
@@ -302,7 +302,6 @@ function testDeepReadonly() {
     Assert<IsExact<DeepReadonly<[1, 2, 3]>, readonly [1, 2, 3]>>,
     Assert<IsExact<DeepReadonly<readonly number[]>, readonly number[]>>,
     Assert<IsExact<DeepReadonly<Array<number>>, ReadonlyArray<number>>>,
-    Assert<IsExact<DeepReadonly<Array<TestUnion>>, ReadonlyTestUnion>>,
     Assert<IsExact<DeepReadonly<Promise<number>>, Promise<number>>>,
     Assert<IsExact<DeepReadonly<{ a: 1; b: 2; c: 3 }>, { a: 1; b: 2; c: 3 }>>,
     Assert<IsExact<DeepReadonly<{ foo: () => void }>, { foo: () => void }>>,
@@ -315,8 +314,16 @@ function testDeepReadonly() {
     Assert<IsExact<DeepReadonly<ComplexNestedRequired>, ComplexNestedReadonly>>,
   ];
 
-  type TestUnion = { value: string } | TestUnion[];
-  type ReadonlyTestUnion = { readonly value: string } | readonly TestUnion[];
+  // Build-time test to ensure the fix for
+  // https://github.com/ts-essentials/ts-essentials/pull/310
+  // because IsExact<> is unable to text it. 
+  {
+    type TestUnion = { value: string } | TestUnion[];
+    type ReadonlyTestUnion = { readonly value: string } | readonly ReadonlyTestUnion[];
+  
+    const a: DeepReadonly<TestUnion> = [];
+    const b: ReadonlyTestUnion = a;
+  }
 
   // Build-time test to ensure the fix for
   // https://github.com/krzkaczor/ts-essentials/issues/17 remains in place.


### PR DESCRIPTION
**Changes:**

- fix DeepReadonly for a union with an array of itself

Resolves #306