### PR TITLE
ci: 🧪 fix changesets from main to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn --no-progress --non-interactive --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@main
+        uses: changesets/action@v1
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
## What

Change `changesets/action@main` to `changesets/action@v1`

## Why

The workflow file using `changesets/action` is currently using `@master` as the version. This branch has been frozen and deprecated. Please update your workflow to either use `@v1` or a specific commit SHA that is tagged.

It's a warning in Version Packages – https://github.com/ts-essentials/ts-essentials/runs/7185388057?check_suite_focus=true

Switching to `main` isn't supported – https://github.com/ts-essentials/ts-essentials/runs/7185463113?check_suite_focus=true