### PR TITLE
refactor(tail): use variadic tuple type

### DIFF
--- a/.changeset/friendly-walls-hope.md
+++ b/.changeset/friendly-walls-hope.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Refactor `Tail` to use variadic tuple type

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -470,7 +470,7 @@ export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U,
 
 /** Functional programming essentials */
 export type Head<T extends AnyArray> = T["length"] extends 0 ? never : T[0];
-export type Tail<T extends AnyArray> = T["length"] extends 0 ? never : T extends [any, ...infer Rest] ? Rest : never;
+export type Tail<T extends AnyArray> = T extends [any, ...infer Rest] ? Rest : never;
 
 export type Exact<T, SHAPE> = T extends SHAPE ? (Exclude<keyof T, keyof SHAPE> extends never ? T : never) : never;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -470,11 +470,7 @@ export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U,
 
 /** Functional programming essentials */
 export type Head<T extends AnyArray> = T["length"] extends 0 ? never : T[0];
-export type Tail<T extends AnyArray> = T["length"] extends 0
-  ? never
-  : ((...t: T) => void) extends (first: any, ...rest: infer Rest) => void
-  ? Rest
-  : never;
+export type Tail<T extends AnyArray> = T["length"] extends 0 ? never : T extends [any, ...infer Rest] ? Rest : never;
 
 export type Exact<T, SHAPE> = T extends SHAPE ? (Exclude<keyof T, keyof SHAPE> extends never ? T : never) : never;
 


### PR DESCRIPTION
Refactored the older function signature to variadic tuple type introduced in TS 4.0