### PR TITLE
feat: ➕ add union support for Mark* methods

### DIFF
--- a/.changeset/nasty-plants-check.md
+++ b/.changeset/nasty-plants-check.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Add union support to all Mark\* methods: `MarkRequired`, `MarkOptional`, `MarkReadonly` and `MarkWritable`

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -398,16 +398,16 @@ type _MergeN<T extends readonly any[], Result> = T extends readonly [infer Head,
 export type MergeN<T extends readonly any[]> = _MergeN<T, {}>;
 
 /** Mark some properties as required, leaving others unchanged */
-export type MarkRequired<T, RK extends keyof T> = Omit<T, RK> & Required<Pick<T, RK>>;
+export type MarkRequired<T, RK extends keyof T> = T extends T ? Omit<T, RK> & Required<Pick<T, RK>> : never;
 
 /** Mark some properties as optional, leaving others unchanged */
-export type MarkOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+export type MarkOptional<T, K extends keyof T> = T extends T ? Omit<T, K> & Partial<Pick<T, K>> : never;
 
 /** Mark some properties as readonly, leaving others unchanged */
-export type MarkReadonly<T, K extends keyof T> = Omit<T, K> & Readonly<Pick<T, K>>;
+export type MarkReadonly<T, K extends keyof T> = T extends T ? Omit<T, K> & Readonly<Pick<T, K>> : never;
 
 /** Mark some properties as writable, leaving others unchanged */
-export type MarkWritable<T, K extends keyof T> = Omit<T, K> & Writable<Pick<T, K>>;
+export type MarkWritable<T, K extends keyof T> = T extends T ? Omit<T, K> & Writable<Pick<T, K>> : never;
 
 /** Convert union type to intersection #darkmagic */
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,11 +11,8 @@ import {
   DeepReadonly,
   DeepRequired,
   DeepWritable,
-  StrictExtract,
   Dictionary,
   DictionaryValues,
-  MarkOptional,
-  MarkRequired,
   Merge,
   MergeN,
   NonEmptyObject,
@@ -853,23 +850,6 @@ function testNonEmptyArray() {
     Assert<Assignable<NonEmptyArray<T>, [T]>>,
     Assert<Assignable<NonEmptyArray<T>, [T, ...T[]]>>,
   ];
-}
-
-function testMarkOptional() {
-  type TestType = {
-    required1: number;
-    required2: string;
-    optional1?: null;
-    optional2?: boolean;
-  };
-  type ExpectedType = {
-    required1?: number;
-    required2: string;
-    optional1?: null;
-    optional2?: boolean;
-  };
-
-  type Test = Assert<IsExact<MarkOptional<TestType, "required1">, ExpectedType>>;
 }
 
 function testMerge() {

--- a/test/mark-optional.ts
+++ b/test/mark-optional.ts
@@ -1,0 +1,30 @@
+import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
+import { MarkOptional, OptionalKeys, RequiredKeys, WritableKeys } from "../lib";
+
+function testMarkOptional() {
+  type Example = {
+    required1: number;
+    required2: string;
+    optional1?: null;
+    optional2?: boolean;
+  };
+
+  type cases = [
+    Assert<IsExact<MarkOptional<Example, never>, Example>>,
+    Assert<IsExact<MarkOptional<Example, OptionalKeys<Example>>, Example>>,
+    Assert<IsExact<MarkOptional<Example, RequiredKeys<Example>>, Partial<Example>>>,
+    Assert<
+      IsExact<
+        MarkOptional<Example, "required1">,
+        {
+          required1?: number;
+          required2: string;
+          optional1?: null;
+          optional2?: boolean;
+        }
+      >
+    >,
+    // @ts-expect-error do NOT support union types
+    MarkOptional<Example | { a: 1 }, "required1">,
+  ];
+}

--- a/test/mark-optional.ts
+++ b/test/mark-optional.ts
@@ -9,6 +9,21 @@ function testMarkOptional() {
     optional2?: boolean;
   };
 
+  type UnionExample = MarkOptional<
+    Pick<Example, "required1" | "optional1"> | Pick<Example, "required2" | "optional1">,
+    "optional1"
+  >;
+
+  let unionElementFields: UnionExample = {
+    required1: 1,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    required2: "2",
+    optional1: null,
+  };
+
   type cases = [
     Assert<IsExact<MarkOptional<Example, never>, Example>>,
     Assert<IsExact<MarkOptional<Example, OptionalKeys<Example>>, Example>>,

--- a/test/mark-readonly.ts
+++ b/test/mark-readonly.ts
@@ -11,6 +11,21 @@ function testMarkReadonly() {
     optional2?: boolean;
   };
 
+  type UnionExample = MarkReadonly<
+    Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">,
+    "optional1"
+  >;
+
+  let unionElementFields: UnionExample = {
+    readonly2: /\w+/g,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    readonly1: new Date(),
+    optional1: null,
+  };
+
   type cases = [
     Assert<IsExact<MarkReadonly<Example, never>, Example>>,
     Assert<IsExact<MarkReadonly<Example, ReadonlyKeys<Example>>, Example>>,

--- a/test/mark-required.ts
+++ b/test/mark-required.ts
@@ -11,6 +11,21 @@ function testMarkRequired() {
     optional2?: boolean;
   };
 
+  type UnionExample = MarkRequired<
+    Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">,
+    "optional1"
+  >;
+
+  let unionElementFields: UnionExample = {
+    readonly2: /\w+/g,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    readonly1: new Date(),
+    optional1: null,
+  };
+
   type cases = [
     Assert<IsExact<MarkRequired<Example, never>, Example>>,
     Assert<IsExact<MarkRequired<Example, RequiredKeys<Example>>, Example>>,
@@ -28,7 +43,7 @@ function testMarkRequired() {
         }
       >
     >,
-    // @ts-expect-error do NOT support union types
+    // @ts-expect-error: throws type error when one of union elements doesn't have property
     MarkRequired<Example | { a: 1 }, "readonly1">,
   ];
 }

--- a/test/mark-writable.ts
+++ b/test/mark-writable.ts
@@ -11,6 +11,21 @@ function testMarkWritable() {
     optional2?: boolean;
   };
 
+  type UnionExample = MarkWritable<
+    Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">,
+    "optional1"
+  >;
+
+  let unionElementFields: UnionExample = {
+    readonly2: /\w+/g,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    readonly1: new Date(),
+    optional1: null,
+  };
+
   type cases = [
     Assert<IsExact<MarkWritable<Example, never>, Example>>,
     Assert<IsExact<MarkWritable<Example, WritableKeys<Example>>, Example>>,


### PR DESCRIPTION
## What

Add union support to all Mark* methods: `MarkRequired`, `MarkOptional`, `MarkReadonly` and `MarkWritable`

## Why

Fix introduced bug – https://github.com/ts-essentials/ts-essentials/issues/323

Codesandbox fix – https://codesandbox.io/s/type-guard-error-forked-dyllt8?file=/src/App.tsx