### PR TITLE
docs: update README comments

### DIFF
--- a/.changeset/two-worms-agree.md
+++ b/.changeset/two-worms-agree.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `StrictExtract` usage for TypeScript@^4.6.0

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -148,6 +148,64 @@ jobs:
       - run: yarn --no-progress --non-interactive --frozen-lockfile
 
       # TypeScript 4.5
-      - run: yarn add typescript@4.5.4
+      - run: yarn add typescript@4.5.5
+      - run: yarn setTsVersion
+      - run: yarn test
+
+  typecheck4_6:
+    name: TypeScript 4.6
+    strategy:
+      matrix:
+        node: ['10.x']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache YARN dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-
+
+      - run: yarn --no-progress --non-interactive --frozen-lockfile
+
+      # TypeScript 4.6
+      - run: yarn add typescript@4.6.4
+      - run: yarn setTsVersion
+      - run: yarn test
+
+  typecheck4_7:
+    name: TypeScript 4.7
+    strategy:
+      matrix:
+        node: ['10.x']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache YARN dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.OS }}-${{ matrix.node }}-yarn-cache-
+
+      - run: yarn --no-progress --non-interactive --frozen-lockfile
+
+      # TypeScript 4.7
+      - run: yarn add typescript@4.7.4
       - run: yarn setTsVersion
       - run: yarn test

--- a/README.md
+++ b/README.md
@@ -474,8 +474,8 @@ Following the code above, we can compare the behavior of `Extract` and `StrictEx
 //     Type '{ type: "horse"; }' is not assignable to type 'Partial<Mouse>'
 //       Types of property 'type' are incompatible
 // @ts-expect-error: Type '"horse"' is not assignable to type '"mouse"'.
-type HouseAnimalWithStrictExtract = StrictExtract<Animal, { type: "dog" | "cat" | "horse" }>;
-//                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+type HouseAnimalWithStrictExtract = StrictExtract<Animal, { type: "dog" } | { type: "cat" } | { type: "horse" }>;
+//                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 // no error
 type HouseAnimalWithExtract = Extract<Animal, { type: "dog" } | { type: "cat" } | { type: "horse" }>;

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you use any [functions](https://github.com/krzkaczor/ts-essentials/blob/maste
     - CamelCase
   - [Writable & DeepWritable](#Writable)
   - [Buildable](#Buildable)
+  - [Pick](#Pick)
   - [Omit](#Omit)
   - [StrictOmit](#StrictOmit)
     - [Comparison between `Omit` and `StrictOmit`](#Comparison-between-Omit-and-StrictOmit)
@@ -366,6 +367,24 @@ buildable.nested.a = "test";
 buildable.nested.array = [];
 buildable.nested.array.push({ bar: 1 });
 const finished = buildable as ReadonlyObject;
+```
+
+### Pick
+
+There's no need for own implementation of `Pick`, as it's already strict:
+
+```typescript
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+//           ^^^^^^^^^^^^^^^^^
+
+interface Person {
+  age: number;
+  name: string;
+}
+
+// @ts-expect-error: Type '"job"' does not satisfy the constraint 'keyof Person'
+type WithJob = Pick<Person, "job">;
+//                          ^^^^^
 ```
 
 ### Omit
@@ -1088,21 +1107,27 @@ assert(anything instanceof String, "anything has to be a string!");
 ```
 
 ### PredicateType
+
 _keywords: narrow, guard, validate_
 
-Works just like [`ReturnType`](https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype) but will return the [predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) associated with the function instead. This is particularly useful if you need to chain guards to narrow broader types.
+Works just like [`ReturnType`](https://www.typescriptlang.org/docs/handbook/utility-types.html#returntypetype) but will
+return the [predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) associated
+with the function instead. This is particularly useful if you need to chain guards to narrow broader types.
 
 ```typescript
 // Without PredicateType you can never use a set of functions like this together; how can you resolve ???
 // You would need a specific instance of isArrayOf for each type you want to narrow
 const isArrayOf = (thing: unknown, validator: (...x: any[]) => boolean): thing is ???[] => {
-  return Array.isArray(thing) && thing.every(validator)
-}
+  return Array.isArray(thing) && thing.every(validator);
+};
 
 // With PredicateType you can pull the predicate of the validator into the higher level guard
-const isArrayOf = <T extends (...x: any[]) => boolean>(thing: unknown, validator: T): thing is Array<PredicateType<T>> => {
-  return Array.isArray(thing) && thing.every(validator)
-}
+const isArrayOf = <T extends (...x: any[]) => boolean>(
+  thing: unknown,
+  validator: T,
+): thing is Array<PredicateType<T>> => {
+  return Array.isArray(thing) && thing.every(validator);
+};
 ```
 
 ### Exact

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ const dictFromUnionType: Dictionary<number, DummyOptions> = {
 };
 
 // and get dictionary values
-type stringDictValues = DictionaryValues<typeof stringDict>;
-// Result: string
+type StringDictionaryValueType = DictionaryValues<typeof stringDict>;
+//   ^? string
 
 // When building a map using JS objects consider using SafeDictionary
 const safeDict: SafeDictionary<number> = {};
@@ -405,17 +405,11 @@ type ComplexObject = {
 };
 
 type SimplifiedComplexObject = StrictOmit<ComplexObject, "nested">;
-
-// Result:
-// {
-//  simple: number
-// }
+//   ^? { simple: number }
 
 // if you want to Omit multiple properties just use union type:
 type SimplifiedComplexObject = StrictOmit<ComplexObject, "nested" | "simple">;
-
-// Result:
-// { } (empty type)
+//   ^? {}
 ```
 
 #### Comparison between `Omit` and `StrictOmit`
@@ -423,15 +417,13 @@ type SimplifiedComplexObject = StrictOmit<ComplexObject, "nested" | "simple">;
 Following the code above, we can compare the behavior of `Omit` and `StrictOmit`.
 
 ```typescript
+// Type '"simple" | "nested" | "nonexistent"' does not satisfy the constraint '"simple" | "nested"'
+// @ts-expect-error: Type '"nonexistent"' is not assignable to type '"simple" | "nested"'
 type SimplifiedComplexObjectWithStrictOmit = StrictOmit<ComplexObject, "nested" | "simple" | "nonexistent">;
-
-// Result: error
-// Type '"simple" | "nested" | "nonexistent"' does not satisfy the constraint '"simple" | "nested"'.
-// Type '"nonexistent"' is not assignable to type '"simple" | "nested"'.
+//                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 type SimplifiedComplexObjectWithOmit = Omit<ComplexObject, "nested" | "simple" | "nonexistent">;
-
-// Result: no error
+//   ^? {}
 ```
 
 As is shown in the example, `StrictOmit` ensures that no extra key is specified in the filter.
@@ -459,15 +451,17 @@ interface Mouse {
 type Animal = Dog | Cat | Mouse;
 
 type DogAnimal = StrictExtract<Animal, { type: "dog" }>;
-
-// Result:
-// Dog
+//   ^? Dog
 
 // if you want to Extract multiple properties just use union type:
-type HouseAnimal = StrictExtract<Animal, { type: "dog" | "cat" }>;
 
-// Result:
-// Cat | Dog
+// 1. if you use typescript up to version 4.5
+type HouseAnimal = StrictExtract<Animal, { type: "dog" | "cat" }>;
+//   ^? Cat | Dog
+
+// 2. otherwise use
+type HouseAnimal = StrictExtract<Animal, { type: "dog" } | { type: "cat" }>;
+//   ^? Cat | Dog
 ```
 
 #### Comparison between `Extract` and `StrictExtract`
@@ -475,15 +469,17 @@ type HouseAnimal = StrictExtract<Animal, { type: "dog" | "cat" }>;
 Following the code above, we can compare the behavior of `Extract` and `StrictExtract`.
 
 ```typescript
+// Type '{ type: "dog"; } | { type: "cat"; } | { type: "horse"; }' does not satisfy the constraint 'Partial<Animal>'
+//   Type '{ type: "horse"; }' is not assignable to type 'Partial<Animal>'
+//     Type '{ type: "horse"; }' is not assignable to type 'Partial<Mouse>'
+//       Types of property 'type' are incompatible
+// @ts-expect-error: Type '"horse"' is not assignable to type '"mouse"'.
 type HouseAnimalWithStrictExtract = StrictExtract<Animal, { type: "dog" | "cat" | "horse" }>;
+//                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-// Result: error
-// Type '"dog" | "cat" | "horse"' is not assignable to type '"mouse" | undefined'
-// Type '"dog"' is not assignable to type '"mouse" | undefined'.
-
-type HouseAnimalWithExtract = Extract<Animal, { type: "dog" | "cat" | "horse" }>;
-
-// Result: no error
+// no error
+type HouseAnimalWithExtract = Extract<Animal, { type: "dog" } | { type: "cat" } | { type: "horse" }>;
+//   ^? Dog | Cat
 ```
 
 ### StrictExclude
@@ -494,15 +490,11 @@ Usage is similar to the builtin version, but checks the filter type more strictl
 type Animal = "dog" | "cat" | "mouse";
 
 type DogAnimal = StrictExclude<Animal, "dog">;
-
-// Result:
-// 'cat' | 'mouse'
+//   ^? 'cat' | 'mouse'
 
 // if you want to Exclude multiple properties just use union type:
-type HouseAnimal = StrictExclude<Animal, "dog" | "cat">;
-
-// Result:
-// 'mouse'
+type MouseAnimal = StrictExclude<Animal, "dog" | "cat">;
+//   ^? 'mouse'
 ```
 
 #### Comparison between `Exclude` and `StrictExclude`
@@ -510,15 +502,12 @@ type HouseAnimal = StrictExclude<Animal, "dog" | "cat">;
 Following the code above, we can compare the behavior of `Exclude` and `StrictExclude`.
 
 ```typescript
+// Type '"dog" | "cat" | "horse"' is not assignable to type '"dog" | "cat" | "mouse"'
+// @ts-expect-error: '"horse"' is not assignable to type '"dog" | "cat" | "mouse"'.
 type HouseAnimalWithStrictExclude = StrictExclude<Animal, "dog" | "cat" | "horse">;
 
-// Result: error
-// Type '"dog" | "cat" | "horse"' is not assignable to type '"dog" | "cat" | "mouse"'
-// Type '"horse"' is not assignable to type '"dog" | "cat" | "mouse"'.
-
+// no error
 type HouseAnimalWithExclude = Exclude<Animal, "dog" | "cat" | "horse">;
-
-// Result: no error
 ```
 
 ### DeepOmit
@@ -551,12 +540,7 @@ type TeacherSimple = DeepOmit<
     }[];
   }
 >;
-
-// The result will be:
-// {
-//  name: string,
-//  students: {name: string}[]
-// }
+// ^? { name: string; students: { name: string }[] }
 ```
 
 NOTE
@@ -595,12 +579,7 @@ type TeacherSimple = DeepPick<
     }[];
   }
 >;
-
-// The result will be:
-// {
-//  gender: string;
-//  students: { score: number }[]
-// }
+// ^? { gender: string; students: { score: number }[] }
 ```
 
 ### OmitProperties
@@ -616,17 +595,11 @@ interface Example {
 }
 
 type ExampleWithoutMethods = OmitProperties<Example, Function>;
+//   ^? { version: string }
 
-// Result:
-// {
-//   version: string;
-// }
-
-// if you want to Omit multiple properties just use union type like
-
+// if you want to Omit multiple properties just use union type like:
 type ExampleWithoutMethods = OmitProperties<Example, Function | string>;
-// Result:
-// { } (empty type)
+//   ^? {}
 ```
 
 ### PickProperties
@@ -641,20 +614,11 @@ interface Example {
 }
 
 type ExampleOnlyMethods = PickProperties<Example, Function>;
+//   ^? { log(): void }
 
-// Result:
-// {
-//   log(): void;
-// }
-
-// if you want to pick multiple properties just use union type like
-
+// if you want to pick multiple properties just use union type like:
 type ExampleOnlyMethodsAndString = PickProperties<Example, Function | string>;
-// Result:
-// {
-//   log(): void;
-//   version: string;
-// }
+//   ^? { log(): void; version: string }
 ```
 
 ### NonNever
@@ -713,11 +677,7 @@ type Bar = {
 };
 
 const xyz: Merge<Foo, Bar> = { a: 4, b: 2 };
-// Result:
-// {
-//   a: number,
-//   b: number,
-// }
+//   ^? { a: number; b: number }
 ```
 
 ### MergeN
@@ -736,11 +696,7 @@ type Tuple = [
 ];
 
 const xyz: MergeN<Tuple> = { a: 4, b: 2 };
-// Result:
-// {
-//   a: number,
-//   b: number,
-// }
+//   ^? { a: number; b: number }
 ```
 
 ### MarkRequired
@@ -768,22 +724,12 @@ Useful when you want to make some properties optional without creating a separat
 
 ```typescript
 interface User {
-  id: number;
-  name: string;
   email: string;
   password: string;
 }
 
 type UserWithoutPassword = MarkOptional<User, "password">;
-
-// Result:
-
-// {
-//   id: number;
-//   name: string;
-//   email: string;
-//   password?: string;
-// }
+//   ^? { email: string; password?: string }
 ```
 
 ### MarkReadonly
@@ -794,20 +740,10 @@ Useful when you want to make some properties readonly without creating a separat
 interface User {
   id: number;
   name: string;
-  email: string;
-  password: string;
 }
 
 type UserThatCannotChangeName = MarkReadonly<User, "name">;
-
-// Result:
-
-// {
-//   id: number;
-//   readonly name: string;
-//   email: string;
-//   password: string;
-// }
+//   ^? { id: number; readonly name: string }
 ```
 
 ### MarkWritable
@@ -818,20 +754,10 @@ Useful when you want to make some properties writable (or unset `readonly`) with
 interface User {
   readonly id: number;
   readonly name: string;
-  readonly email: string;
-  readonly password: string;
 }
 
 type UserThatCanChangeName = MarkWritable<User, "name">;
-
-// Result:
-
-// {
-//   readonly id: number;
-//   name: string;
-//   readonly email: string;
-//   readonly password: string;
-// }
+//   ^? { readonly id: number; name: string }
 ```
 
 ### ReadonlyKeys
@@ -843,9 +769,9 @@ type T = {
   readonly a: number;
   b: string;
 };
+
 type Result = ReadonlyKeys<T>;
-// Result:
-// "a"
+//   ^? 'a'
 ```
 
 ### WritableKeys
@@ -857,9 +783,9 @@ type T = {
   readonly a: number;
   b: string;
 };
+
 type Result = WritableKeys<T>;
-// Result:
-// "b"
+//   ^? 'b'
 ```
 
 ### OptionalKeys
@@ -873,9 +799,9 @@ type T = {
   c: string | undefined;
   d?: string;
 };
+
 type Result = OptionalKeys<T>;
-// Result:
-// "b" | "d"
+//   ^? 'b' | 'd'
 ```
 
 ### RequiredKeys
@@ -889,9 +815,9 @@ type T = {
   c: string | undefined;
   d?: string;
 };
+
 type Result = RequiredKeys<T>;
-// Result:
-// "a" | "c"
+//   ^? 'a' | 'c'
 ```
 
 ### PickKeys
@@ -905,12 +831,12 @@ type T = {
   c: string | undefined;
   d: string;
 };
+
 type Result1 = PickKeys<T, string>;
-// Result1:
-// "d"
+//   ^? 'd'
+
 type Result2 = PickKeys<T, string | undefined>;
-// Result2:
-// "b" | "c" | "d"
+//   ^? 'b' | 'c' | 'd'
 ```
 
 ### UnionToIntersection
@@ -1004,16 +930,17 @@ const obj = {
   timestamp: 1548768231486,
 };
 
-type objKeys = ValueOf<typeof obj>;
-// Result: string | number
+type ObjectValueType = ValueOf<typeof obj>;
+//   ^? string | number
 ```
 
 ### ElementOf type
 
 ```typescript
 const array = [1, 2, true, false];
-type arrayElement = ElementOf<typeof array>;
-// Result: number | boolean
+
+type ArrayElementType = ElementOf<typeof array>;
+//   ^? number | boolean
 ```
 
 ### ArrayOrSingle

--- a/lib/literal-types/README.md
+++ b/lib/literal-types/README.md
@@ -13,12 +13,14 @@
 - PascalCase
 
 ```typescript
-// 'oneword'
-type Example1 = CamelCase<"ONEWORD">;
-// 'twoWords'
-type Example2 = CamelCase<"two_words">;
-// 'hereThreeWords'
-type Example3 = CamelCase<"HERE-THREE-WORDS">;
+type OneWordExample = CamelCase<"ONEWORD">;
+//   ^? 'oneword'
+
+type TwoWordsExample = CamelCase<"two_words">;
+//   ^? 'twoWords'
+
+type ThreeWordsExample = CamelCase<"HERE-THREE-WORDS">;
+//   ^? 'hereThreeWords'
 ```
 
 ## DeepCamelCaseProperties
@@ -33,6 +35,6 @@ type Input = {
   };
 };
 
-// { oneword: 1; twoWords: { hereThreeWords: false } }
 type Example = DeepCamelCaseProperties<Input>;
+//   ^? { oneword: 1; twoWords: { hereThreeWords: false } }
 ```

--- a/test/strict-extract.ts
+++ b/test/strict-extract.ts
@@ -1,5 +1,6 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
 import { StrictExtract } from "../lib";
+import { TsVersion } from "./ts-version";
 
 function testStrictExtract() {
   interface Dog {
@@ -36,9 +37,31 @@ function testStrictExtract() {
     Assert<IsExact<StrictExtract<Animal, { type: "mouse" }>, Mouse>>,
     // @ts-expect-error
     StrictExtract<Animal, "cat" | "dog">,
-    Assert<IsExact<StrictExtract<Animal, { type: "cat" | "dog" }>, Cat | Dog>>,
+    Assert<
+      IsExact<
+        StrictExtract<
+          Animal,
+          TsVersion extends "4.1" | "4.2" | "4.3" | "4.4" | "4.5"
+            ? { type: "cat" | "dog" }
+            : { type: "cat" } | { type: "dog" }
+        >,
+        Cat | Dog
+      >
+    >,
+    Assert<IsExact<StrictExtract<Animal, { type: "cat" } | { type: "dog" }>, Cat | Dog>>,
     // @ts-expect-error
     StrictExtract<Animal, "cat" | "dog" | "mouse">,
-    Assert<IsExact<StrictExtract<Animal, { type: "cat" | "dog" | "mouse" }>, Animal>>,
+    Assert<
+      IsExact<
+        StrictExtract<
+          Animal,
+          TsVersion extends "4.1" | "4.2" | "4.3" | "4.4" | "4.5"
+            ? { type: "cat" | "dog" | "mouse" }
+            : { type: "cat" } | { type: "dog" } | { type: "mouse" }
+        >,
+        Animal
+      >
+    >,
+    Assert<IsExact<StrictExtract<Animal, { type: "cat" } | { type: "dog" } | { type: "mouse" }>, Animal>>,
   ];
 }

--- a/test/ts-version.ts
+++ b/test/ts-version.ts
@@ -1,1 +1,1 @@
-export type TsVersion = "4.4";
+export type TsVersion = "4.7";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,9 +2138,9 @@ type-fest@^0.8.1:
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 typescript@^4.1.0:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
## What

1. Replace `Result:` with `^?` comments
2. Update `HouseAnimalWithStrictExtract` example for `StrictExtract` since version 4.6 and higher
3. Add more CI checks for newer TypeScript versions
4. Use typescript@4.7.x locally

## Why

1. It looks more familiar for TypeScript community
2. Example in README leads to TypeError now
3. To be able to keep README up-to-date
4. To be able to see changes in the codebase