### PR TITLE
Improve the Output range and cover edge cases for `ValueOf<T>` type

### DIFF
--- a/.changeset/rare-forks-deliver.md
+++ b/.changeset/rare-forks-deliver.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Improve the `ValueOf` utility type to cover the edge cases

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,7 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
 export type IsNever<T> = [T] extends [never] ? true : false;
 export type IsUnknown<T> = IsAny<T> extends true ? false : unknown extends T ? true : false;
 export type AnyArray<T = any> = Array<T> | ReadonlyArray<T>;
+export type AnyFunction<TArgs extends any[] = any[], TReturnType = any> = (...args: TArgs) => TReturnType;
 
 export type ArrayOrSingle<T> = T | T[];
 
@@ -426,9 +427,9 @@ export type Opaque<Type, Token extends string> = Token extends StringLiteral<Tok
 /** Easily extract the type of a given object's values */
 export type ValueOf<T> = T extends Primitive
   ? T
-  : T extends any[]
+  : T extends AnyArray
   ? T[number]
-  : T extends (...args: any[]) => any
+  : T extends AnyFunction
   ? ReturnType<T>
   : T[keyof T];
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -424,7 +424,13 @@ export type Opaque<Type, Token extends string> = Token extends StringLiteral<Tok
   : never;
 
 /** Easily extract the type of a given object's values */
-export type ValueOf<T> = T[keyof T];
+export type ValueOf<T> = T extends Primitive
+  ? T
+  : T extends any[]
+  ? T[number]
+  : T extends (...args: any[]) => any
+  ? ReturnType<T>
+  : T[keyof T];
 
 /** Easily extract the type of a given array's elements */
 export type ElementOf<T extends readonly any[]> = T extends readonly (infer ET)[] ? ET : never;

--- a/test/value-of.ts
+++ b/test/value-of.ts
@@ -1,0 +1,34 @@
+﻿import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
+import { ValueOf, Primitive } from "../lib/types";
+
+declare const array: number[] | undefined;
+declare const func: (...arg: any[]) => boolean;
+declare const obj: { propA: string; propB: number; propC: () => void };
+declare const tuple: [1, 2, 3, 4];
+declare const primitive: Primitive;
+declare const primitiveOrObject: Primitive | typeof obj;
+declare const objOrFunc: typeof func | typeof obj;
+
+function testValueOf() {
+  type cases = [
+    Assert<IsExact<ValueOf<typeof obj>, string | number | (() => void)>>,
+    Assert<IsExact<ValueOf<typeof array>, number | undefined>>,
+    Assert<IsExact<ValueOf<typeof func>, boolean>>,
+    Assert<IsExact<ValueOf<typeof tuple>, 1 | 2 | 3 | 4>>,
+    Assert<IsExact<ValueOf<string>, string>>,
+    // valueOf for constant primitive literals will be the literal type
+    Assert<IsExact<ValueOf<"const">, "const">>,
+    Assert<IsExact<ValueOf<23>, 23>>,
+    Assert<IsExact<ValueOf<undefined>, undefined>>,
+    Assert<IsExact<ValueOf<{ a: "1"; b: 2 }>, "1" | 2>>,
+    // Combination of these types
+    Assert<IsExact<ValueOf<typeof primitive>, Primitive>>,
+    Assert<IsExact<ValueOf<typeof primitiveOrObject>, ValueOf<Primitive> | ValueOf<typeof obj>>>,
+    Assert<IsExact<ValueOf<typeof objOrFunc>, ValueOf<typeof obj | ValueOf<typeof func>>>>,
+    Assert<IsExact<ValueOf<23 | number>, number>>,
+    Assert<IsExact<ValueOf<[number[], string[]]>, number[] | string[]>>,
+    Assert<IsExact<ValueOf<number[] | string | null>, number | string | null>>,
+    Assert<IsExact<ValueOf<boolean[] | typeof obj>, boolean | ValueOf<typeof obj>>>,
+    Assert<IsExact<ValueOf<[string, number] | { keyA: bigint; keyB: null }>, string | number | bigint | null>>,
+  ];
+}

--- a/test/value-of.ts
+++ b/test/value-of.ts
@@ -3,11 +3,13 @@ import { ValueOf, Primitive, AnyArray } from "../lib/types";
 
 declare const array: number[];
 declare const func: (...arg: any[]) => boolean;
-declare const obj: { propA: string; propB: number; propC: () => void };
+declare const writableObj: { propA: string; propB: number; propC: () => void };
+declare const optionalObj: { propA?: string; propB?: number; propC?: () => void };
+declare const readonlyObj: { readonly propA: string; readonly propB: number; readonly propC: () => void };
 declare const tuple: [boolean, string, number];
 declare const primitive: Primitive;
-declare const primitiveOrObject: Primitive | typeof obj;
-declare const objOrFunc: typeof func | typeof obj;
+declare const primitiveOrObject: Primitive | typeof writableObj;
+declare const objOrFunc: typeof func | typeof writableObj;
 declare const arrayOrUndefined: number[] | undefined;
 
 // declare const readonly
@@ -18,7 +20,9 @@ declare const readonlyTupleOrUndefined: readonly [boolean, string, number] | und
 
 function testValueOf() {
   type cases = [
-    Assert<IsExact<ValueOf<typeof obj>, string | number | (() => void)>>,
+    Assert<IsExact<ValueOf<typeof writableObj>, string | number | (() => void)>>,
+    Assert<IsExact<ValueOf<typeof optionalObj>, string | number | (() => void) | undefined>>,
+    Assert<IsExact<ValueOf<typeof readonlyObj>, string | number | (() => void)>>,
     Assert<IsExact<ValueOf<typeof array>, number>>,
     Assert<IsExact<ValueOf<typeof arrayOrUndefined>, number | undefined>>,
     Assert<IsExact<ValueOf<typeof readonlyArray>, string | number>>,
@@ -37,11 +41,11 @@ function testValueOf() {
     Assert<IsExact<ValueOf<{ a: "1"; b: 2 }>, "1" | 2>>,
     // Combination of these types
     Assert<IsExact<ValueOf<typeof primitive>, Primitive>>,
-    Assert<IsExact<ValueOf<typeof primitiveOrObject>, ValueOf<Primitive> | ValueOf<typeof obj>>>,
-    Assert<IsExact<ValueOf<typeof objOrFunc>, ValueOf<typeof obj | ValueOf<typeof func>>>>,
+    Assert<IsExact<ValueOf<typeof primitiveOrObject>, ValueOf<Primitive> | ValueOf<typeof writableObj>>>,
+    Assert<IsExact<ValueOf<typeof objOrFunc>, ValueOf<typeof writableObj | ValueOf<typeof func>>>>,
     Assert<IsExact<ValueOf<[number[], string[]]>, number[] | string[]>>,
     Assert<IsExact<ValueOf<number[] | string | null>, number | string | null>>,
-    Assert<IsExact<ValueOf<boolean[] | typeof obj>, boolean | ValueOf<typeof obj>>>,
+    Assert<IsExact<ValueOf<boolean[] | typeof writableObj>, boolean | ValueOf<typeof writableObj>>>,
     Assert<IsExact<ValueOf<[string, number] | { keyA: bigint; keyB: null }>, string | number | bigint | null>>,
   ];
 }

--- a/test/value-of.ts
+++ b/test/value-of.ts
@@ -1,21 +1,35 @@
 ﻿import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
-import { ValueOf, Primitive } from "../lib/types";
+import { ValueOf, Primitive, AnyArray } from "../lib/types";
 
-declare const array: number[] | undefined;
+declare const array: number[];
 declare const func: (...arg: any[]) => boolean;
 declare const obj: { propA: string; propB: number; propC: () => void };
-declare const tuple: [1, 2, 3, 4];
+declare const tuple: [boolean, string, number];
 declare const primitive: Primitive;
 declare const primitiveOrObject: Primitive | typeof obj;
 declare const objOrFunc: typeof func | typeof obj;
+declare const arrayOrUndefined: number[] | undefined;
+
+// declare const readonly
+declare const readonlyArray: AnyArray<string | number>;
+declare const readonlyArrayOrUndefined: AnyArray<string | number> | undefined;
+declare const readonlyTuple: readonly [boolean, string, number];
+declare const readonlyTupleOrUndefined: readonly [boolean, string, number] | undefined;
 
 function testValueOf() {
   type cases = [
     Assert<IsExact<ValueOf<typeof obj>, string | number | (() => void)>>,
-    Assert<IsExact<ValueOf<typeof array>, number | undefined>>,
+    Assert<IsExact<ValueOf<typeof array>, number>>,
+    Assert<IsExact<ValueOf<typeof arrayOrUndefined>, number | undefined>>,
+    Assert<IsExact<ValueOf<typeof readonlyArray>, string | number>>,
+    Assert<IsExact<ValueOf<typeof readonlyArrayOrUndefined>, string | number | undefined>>,
+    Assert<IsExact<ValueOf<typeof tuple>, boolean | string | number>>,
+    Assert<IsExact<ValueOf<typeof readonlyTuple>, boolean | string | number>>,
+    Assert<IsExact<ValueOf<typeof readonlyTupleOrUndefined>, boolean | string | number | undefined>>,
     Assert<IsExact<ValueOf<typeof func>, boolean>>,
-    Assert<IsExact<ValueOf<typeof tuple>, 1 | 2 | 3 | 4>>,
     Assert<IsExact<ValueOf<string>, string>>,
+    Assert<IsExact<ValueOf<Array<number | undefined>>, number | undefined>>,
+    Assert<IsExact<ValueOf<AnyArray<number | undefined>>, number | undefined>>,
     // valueOf for constant primitive literals will be the literal type
     Assert<IsExact<ValueOf<"const">, "const">>,
     Assert<IsExact<ValueOf<23>, 23>>,
@@ -25,7 +39,6 @@ function testValueOf() {
     Assert<IsExact<ValueOf<typeof primitive>, Primitive>>,
     Assert<IsExact<ValueOf<typeof primitiveOrObject>, ValueOf<Primitive> | ValueOf<typeof obj>>>,
     Assert<IsExact<ValueOf<typeof objOrFunc>, ValueOf<typeof obj | ValueOf<typeof func>>>>,
-    Assert<IsExact<ValueOf<23 | number>, number>>,
     Assert<IsExact<ValueOf<[number[], string[]]>, number[] | string[]>>,
     Assert<IsExact<ValueOf<number[] | string | null>, number | string | null>>,
     Assert<IsExact<ValueOf<boolean[] | typeof obj>, boolean | ValueOf<typeof obj>>>,


### PR DESCRIPTION
Added the basic test coverage for `ValueOf<T>`.
@Beraliv Feel free to add more test cases or if we need to check the behavior for other edge cases as well. 

fixes #333 