### PR TITLE
fix the object constraint for `NonEmptyObject<T>`

### DIFF
--- a/.changeset/great-hounds-brush.md
+++ b/.changeset/great-hounds-brush.md
@@ -2,4 +2,4 @@
 "ts-essentials": patch
 ---
 
-improve the object constraint for `NonEmptyObject<T>` to not allow primitives
+Improve the object constraint for `NonEmptyObject<T>` to not allow primitives

--- a/.changeset/great-hounds-brush.md
+++ b/.changeset/great-hounds-brush.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+improve the object constraint for `NonEmptyObject<T>` to not allow primitives

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -385,7 +385,7 @@ type DeepModify<T> =
 /** Remove keys with `never` value from object type */
 export type NonNever<T extends {}> = Pick<T, { [K in keyof T]: T[K] extends never ? never : K }[keyof T]>;
 
-export type NonEmptyObject<T extends {}> = keyof T extends never ? never : T;
+export type NonEmptyObject<T extends Record<PropertyKey, any>> = keyof T extends never ? never : T;
 
 export type NonEmptyArray<T> = [T, ...T[]];
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -385,7 +385,7 @@ type DeepModify<T> =
 /** Remove keys with `never` value from object type */
 export type NonNever<T extends {}> = Pick<T, { [K in keyof T]: T[K] extends never ? never : K }[keyof T]>;
 
-export type NonEmptyObject<T extends Record<PropertyKey, any>> = keyof T extends never ? never : T;
+export type NonEmptyObject<T extends AnyRecord> = keyof T extends never ? never : T;
 
 export type NonEmptyArray<T> = [T, ...T[]];
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -15,7 +15,6 @@ import {
   DictionaryValues,
   Merge,
   MergeN,
-  NonEmptyObject,
   NonNever,
   noop,
   PickProperties,
@@ -831,26 +830,6 @@ function testNonNever() {
 
   type TestA = Assert<IsExact<keyof Mapped, "foo" | "bar" | "xyz">>;
   type TestB = Assert<IsExact<keyof NonNever<Mapped>, "foo" | "bar">>;
-}
-
-function testNonEmptyObject() {
-  type ObjectWithKeys = { foo: string; bar: number; xyz: undefined };
-  type EmptyObject = {};
-
-  type Cases = [
-    Assert<IsExact<NonEmptyObject<ObjectWithKeys>, ObjectWithKeys>>,
-    Assert<IsExact<NonEmptyObject<EmptyObject>, never>>,
-    // Works with Wrapper Object Types
-    Assert<IsExact<NonEmptyObject<String>, String>>,
-    Assert<IsExact<NonEmptyObject<Number>, Number>>,
-    Assert<IsExact<NonEmptyObject<Boolean>, Boolean>>,
-    // @ts-expect-error
-    Assert<IsExact<NonEmptyObject<string>, string>>, // Will Not work as T is a Primitive
-    // @ts-expect-error
-    Assert<IsExact<NonEmptyObject<number>, number>>, // Will Not work as T is a Primitive
-    // @ts-expect-error
-    Assert<IsExact<NonEmptyObject<undefined>, number>>, // Will Not work as T is a Primitive
-  ];
 }
 
 function testNonEmptyArray() {

--- a/test/index.ts
+++ b/test/index.ts
@@ -44,6 +44,7 @@ import {
   ArrayOrSingle,
   IsAny,
   NonEmptyArray,
+  Primitive,
 } from "../lib";
 import { TsVersion } from "./ts-version";
 import { ComplexNestedPartial, ComplexNestedRequired } from "./types";
@@ -836,8 +837,20 @@ function testNonEmptyObject() {
   type ObjectWithKeys = { foo: string; bar: number; xyz: undefined };
   type EmptyObject = {};
 
-  type TestA = Assert<IsExact<NonEmptyObject<ObjectWithKeys>, ObjectWithKeys>>;
-  type TestB = Assert<IsExact<NonEmptyObject<EmptyObject>, never>>;
+  type Cases = [
+    Assert<IsExact<NonEmptyObject<ObjectWithKeys>, ObjectWithKeys>>,
+    Assert<IsExact<NonEmptyObject<EmptyObject>, never>>,
+    // Works with Wrapper Object Types
+    Assert<IsExact<NonEmptyObject<String>, String>>,
+    Assert<IsExact<NonEmptyObject<Number>, Number>>,
+    Assert<IsExact<NonEmptyObject<Boolean>, Boolean>>,
+    // @ts-expect-error
+    Assert<IsExact<NonEmptyObject<string>, string>>, // Will Not work as T is a Primitive
+    // @ts-expect-error
+    Assert<IsExact<NonEmptyObject<number>, number>>, // Will Not work as T is a Primitive
+    // @ts-expect-error
+    Assert<IsExact<NonEmptyObject<undefined>, number>>, // Will Not work as T is a Primitive
+  ];
 }
 
 function testNonEmptyArray() {

--- a/test/non-empty-object.ts
+++ b/test/non-empty-object.ts
@@ -1,0 +1,22 @@
+﻿import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
+import { NonEmptyObject } from "../lib";
+
+function testNonEmptyObject() {
+  type ObjectWithKeys = { foo: string; bar: number; xyz: undefined };
+  type EmptyObject = {};
+
+  type Cases = [
+    Assert<IsExact<NonEmptyObject<ObjectWithKeys>, ObjectWithKeys>>,
+    Assert<IsExact<NonEmptyObject<EmptyObject>, never>>,
+    // Works with Wrapper Object Types
+    Assert<IsExact<NonEmptyObject<String>, String>>,
+    Assert<IsExact<NonEmptyObject<Number>, Number>>,
+    Assert<IsExact<NonEmptyObject<Boolean>, Boolean>>,
+    //   @ts-expect-error
+    Assert<IsExact<NonEmptyObject<string>, string>>, // Will Not work as T is a Primitive
+    // @ts-expect-error
+    Assert<IsExact<NonEmptyObject<number>, number>>, // Will Not work as T is a Primitive
+    // @ts-expect-error
+    Assert<IsExact<NonEmptyObject<undefined>, number>>, // Will Not work as T is a Primitive
+  ];
+}


### PR DESCRIPTION
fixed #335 

@Beraliv 
Have also added the additional test cases for the improved constraint!