### PR TITLE
Tweak `Tuple` type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -437,7 +437,7 @@ export type ValueOf<T> = T extends Primitive
 export type ElementOf<T extends readonly any[]> = T extends readonly (infer ET)[] ? ET : never;
 
 /** Type constraint for tuple inference */
-export type Tuple<T = any> = [T] | T[];
+export type Tuple<T = any> = [T?, ...T[]];
 
 /** Useful as a return type in interfaces or abstract classes with missing implementation */
 export type AsyncOrSync<T> = PromiseLike<T> | T;


### PR DESCRIPTION
This is probably a little bit saner way of declaring this constraint. The union trick is neat but a little bit hacky - the revised version uses the actual tuple type (without mixing it with an array) so it idiomatically makes sense why it works (well, I also understand why the union works as well but it always "looked off" to me). 

Arrays stay assignable to this and all tuples should still stay assignable to it (except the ones containing `never` types but that wasn't quite supported before either). 

Conceptually this should also work `[...any[]]` but unfortunately, this "simplifies" to just `any[]`, and by the time TS checks if the contextual type might be a tuple - it no longer is.

Feel free to close this PR, I mostly just opened it to have a reference to this thing - so I will always know where to find this 😅 