### PR TITLE
fix: Opaque that works

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -419,10 +419,12 @@ type StringLiteral<T> = T extends string ? (string extends T ? never : T) : neve
 
 declare const __OPAQUE_TYPE__: unique symbol;
 
+export type WithOpaque<Token extends string> = {
+  readonly [__OPAQUE_TYPE__]: Token;
+};
+
 /** Easily create opaque types ie. types that are subset of their original types (ex: positive numbers, uppercased string) */
-export type Opaque<Type, Token extends string> = Token extends StringLiteral<Token>
-  ? Type & { readonly [__OPAQUE_TYPE__]: Token }
-  : never;
+export type Opaque<Type, Token extends string> = Token extends StringLiteral<Token> ? Type & WithOpaque<Token> : never;
 
 /** Easily extract the type of a given object's values */
 export type ValueOf<T> = T extends Primitive


### PR DESCRIPTION
Apparently, current upstream implementation of `Opaque` is unusable. It leads to this error: https://github.com/microsoft/TypeScript/issues/37888

This PR changes slightly the code, so that now consumers of `ts-essential` can actually use `Opaque` type.