### PR TITLE
ci: 🔄 Use default issue and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## You must use one of our issue templates to file an issue.
+
+## [https://github.com/ts-essentials/ts-essentials/issues/new/choose](https://github.com/ts-essentials/ts-essentials/issues/new/choose)
+
+## Issues filed without using a template will be closed without action, and we will ask you to use a template.
+
+## [https://github.com/ts-essentials/ts-essentials/issues/new/choose](https://github.com/ts-essentials/ts-essentials/issues/new/choose)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--
+👋 Hi, thanks for sending a PR to ts-essentials! 🧡
+Please fill out all fields below and make sure each item is true and [x] checked.
+Otherwise we may not be able to review your PR.
+-->
+
+## PR Checklist
+
+- [ ] Addresses an existing open issue: related to #000
+- [ ] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken
+
+## Overview
+
+<!-- Description of what is changed and how the code change does that. -->


### PR DESCRIPTION
## Overview

It introduces PR template for all contributors to fill

Other changes:

- Added default issue template to warn contributors to use existing templates

It will help to validate that people are reading [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) guide and linking PRs to existing issues