### PR TITLE
fix: Assignability for Mark* utility types

### DIFF
--- a/lib/mark-readonly/index.ts
+++ b/lib/mark-readonly/index.ts
@@ -1,3 +1,7 @@
+import { ReadonlyKeys } from "../readonly-keys";
+import { Writable } from "../writable";
+
 export type MarkReadonly<Type, Keys extends keyof Type> = Type extends Type
-  ? Omit<Type, Keys> & Readonly<Pick<Type, Keys>>
+  ? Readonly<Type> &
+      Writable<Pick<Type, Exclude<keyof Type, Keys | (Type extends object ? ReadonlyKeys<Type> : never)>>>
   : never;

--- a/lib/mark-required/index.ts
+++ b/lib/mark-required/index.ts
@@ -1,3 +1,1 @@
-export type MarkRequired<Type, Keys extends keyof Type> = Type extends Type
-  ? Omit<Type, Keys> & Required<Pick<Type, Keys>>
-  : never;
+export type MarkRequired<Type, Keys extends keyof Type> = Type extends Type ? Type & Required<Pick<Type, Keys>> : never;

--- a/lib/mark-writable/index.ts
+++ b/lib/mark-writable/index.ts
@@ -1,5 +1,6 @@
 import { Writable } from "../writable";
+import { WritableKeys } from "../writable-keys";
 
 export type MarkWritable<Type, Keys extends keyof Type> = Type extends Type
-  ? Omit<Type, Keys> & Writable<Pick<Type, Keys>>
+  ? Readonly<Type> & Writable<Pick<Type, (Type extends object ? WritableKeys<Type> : never) | Keys>>
   : never;

--- a/test/mark-optional.ts
+++ b/test/mark-optional.ts
@@ -1,29 +1,15 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
 import { MarkOptional, OptionalKeys, RequiredKeys } from "../lib";
+import { Debug } from "./types";
+
+type Example = {
+  required1: number;
+  required2: string;
+  optional1?: null;
+  optional2?: boolean;
+};
 
 function testMarkOptional() {
-  type Example = {
-    required1: number;
-    required2: string;
-    optional1?: null;
-    optional2?: boolean;
-  };
-
-  type UnionExample = MarkOptional<
-    Pick<Example, "required1" | "optional1"> | Pick<Example, "required2" | "optional1">,
-    "optional1"
-  >;
-
-  let unionElementFields: UnionExample = {
-    required1: 1,
-    optional1: null,
-  };
-
-  unionElementFields = {
-    required2: "2",
-    optional1: null,
-  };
-
   type cases = [
     Assert<IsExact<MarkOptional<Example, never>, Example>>,
     Assert<IsExact<MarkOptional<Example, OptionalKeys<Example>>, Example>>,
@@ -42,4 +28,47 @@ function testMarkOptional() {
     // @ts-expect-error do NOT support union types
     MarkOptional<Example | { a: 1 }, "required1">,
   ];
+}
+
+function testUnionTypes() {
+  type UnionExample = Debug<
+    MarkOptional<Pick<Example, "required1" | "optional1"> | Pick<Example, "required2" | "optional1">, "optional1">
+  >;
+
+  let unionElementFields: UnionExample = {
+    required1: 1,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    required2: "2",
+    optional1: null,
+  };
+}
+
+declare let example: Example;
+declare let optionalExample: Partial<Example>;
+declare let markedOptionalExample: Debug<MarkOptional<Example, "required1">>;
+
+function testAssignability() {
+  // @ts-expect-error: Type 'Partial<Example>' is not assignable to type 'Example'
+  example = optionalExample;
+  // @ts-expect-error: Type 'Omit<Example, "required1"> & Partial<Pick<Example, "required1">>' is not assignable to type 'Example'
+  example = markedOptionalExample;
+  optionalExample = example;
+  markedOptionalExample = example;
+
+  // it verifies that type `Partial<Type>` is NOT assignable to type `Type`
+
+  // @ts-expect-error: Type 'Partial<Type>' is not assignable to type 'Type'
+  let assignabilityCheck1: <Type>(object: Type) => object is Partial<Type>;
+
+  // it verifies that type `MarkOptional<Type, PropertyName>`
+  // is NOT assignable to type `Type`
+
+  let assignabilityCheck2: <Type, PropertyName extends keyof Type>(
+    object: Type,
+    propertyNames: PropertyName[],
+    // @ts-expect-error: Type 'MarkOptional<Type, PropertyName>' is not assignable to type 'Type'
+  ) => object is MarkOptional<Type, PropertyName>;
 }

--- a/test/mark-readonly.ts
+++ b/test/mark-readonly.ts
@@ -1,19 +1,32 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
 import { MarkReadonly, WritableKeys, ReadonlyKeys } from "../lib";
+import { Debug } from "./types";
+
+type Example = {
+  readonly readonly1: Date;
+  readonly readonly2: RegExp;
+  required1: number;
+  required2: string;
+  optional1?: null;
+  optional2?: boolean;
+};
 
 function testMarkReadonly() {
-  type Example = {
-    readonly readonly1: Date;
-    readonly readonly2: RegExp;
-    required1: number;
-    required2: string;
-    optional1?: null;
-    optional2?: boolean;
-  };
+  type ExampleWithReadonlyRequired1 = Debug<MarkReadonly<Example, "required1">>;
 
-  type UnionExample = MarkReadonly<
-    Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">,
-    "optional1"
+  type cases = [
+    Assert<IsExact<MarkReadonly<Example, never>, Example>>,
+    Assert<IsExact<MarkReadonly<Example, ReadonlyKeys<Example>>, Example>>,
+    Assert<IsExact<MarkReadonly<Example, WritableKeys<Example>>, Readonly<Example>>>,
+    Assert<IsExact<ReadonlyKeys<ExampleWithReadonlyRequired1>, "readonly1" | "readonly2" | "required1">>,
+    // @ts-expect-error do NOT support union types
+    MarkReadonly<Example | { a: 1 }, "required1">,
+  ];
+}
+
+function testUnionTypes() {
+  type UnionExample = Debug<
+    MarkReadonly<Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">, "optional1">
   >;
 
   let unionElementFields: UnionExample = {
@@ -25,25 +38,27 @@ function testMarkReadonly() {
     readonly1: new Date(),
     optional1: null,
   };
+}
 
-  type cases = [
-    Assert<IsExact<MarkReadonly<Example, never>, Example>>,
-    Assert<IsExact<MarkReadonly<Example, ReadonlyKeys<Example>>, Example>>,
-    Assert<IsExact<MarkReadonly<Example, WritableKeys<Example>>, Readonly<Example>>>,
-    Assert<
-      IsExact<
-        MarkReadonly<Example, "required1">,
-        {
-          readonly readonly1: Date;
-          readonly readonly2: RegExp;
-          readonly required1: number;
-          required2: string;
-          optional1?: null;
-          optional2?: boolean;
-        }
-      >
-    >,
-    // @ts-expect-error do NOT support union types
-    MarkReadonly<Example | { a: 1 }, "required1">,
-  ];
+declare let example: Example;
+declare let readonlyExample: Readonly<Example>;
+declare let markedReadonlyExample: MarkReadonly<Example, "optional1">;
+
+function testAssignability() {
+  example = readonlyExample;
+  example = markedReadonlyExample;
+  readonlyExample = example;
+  markedReadonlyExample = example;
+
+  // it verifies that type `Readonly<Type>` is assignable to type `Type`
+
+  let assignabilityCheck1: <Type>(object: Type) => object is Readonly<Type>;
+
+  // it verifies that type `MarkReadonly<Type, PropertyName>`
+  // is assignable to type `Type`
+
+  let assignabilityCheck2: <Type, PropertyName extends keyof Type>(
+    object: Type,
+    propertyNames: PropertyName[],
+  ) => object is MarkReadonly<Type, PropertyName>;
 }

--- a/test/mark-required.ts
+++ b/test/mark-required.ts
@@ -1,31 +1,17 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
 import { MarkRequired, RequiredKeys, OptionalKeys } from "../lib";
+import { Debug } from "./types";
+
+type Example = {
+  readonly readonly1: Date;
+  readonly readonly2: RegExp;
+  required1: number;
+  required2: string;
+  optional1?: null;
+  optional2?: boolean;
+};
 
 function testMarkRequired() {
-  type Example = {
-    readonly readonly1: Date;
-    readonly readonly2: RegExp;
-    required1: number;
-    required2: string;
-    optional1?: null;
-    optional2?: boolean;
-  };
-
-  type UnionExample = MarkRequired<
-    Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">,
-    "optional1"
-  >;
-
-  let unionElementFields: UnionExample = {
-    readonly2: /\w+/g,
-    optional1: null,
-  };
-
-  unionElementFields = {
-    readonly1: new Date(),
-    optional1: null,
-  };
-
   type cases = [
     Assert<IsExact<MarkRequired<Example, never>, Example>>,
     Assert<IsExact<MarkRequired<Example, RequiredKeys<Example>>, Example>>,
@@ -46,4 +32,45 @@ function testMarkRequired() {
     // @ts-expect-error: throws type error when one of union elements doesn't have property
     MarkRequired<Example | { a: 1 }, "readonly1">,
   ];
+}
+
+function testUnionTypes() {
+  type UnionExample = Debug<
+    MarkRequired<Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">, "optional1">
+  >;
+
+  let unionElementFields: UnionExample = {
+    readonly2: /\w+/g,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    readonly1: new Date(),
+    optional1: null,
+  };
+}
+
+declare let example: Example;
+declare let requiredExample: Required<Example>;
+declare let markedRequiredExample: Debug<MarkRequired<Example, "optional1">>;
+
+function testAssignability() {
+  example = requiredExample;
+  example = markedRequiredExample;
+  // @ts-expect-error: Type 'Example' is not assignable to type 'Required<Example>'
+  requiredExample = example;
+  // @ts-expect-error: Type 'Example' is not assignable to type 'Required<Pick<Example, "optional1">>'
+  markedRequiredExample = example;
+
+  // it verifies that type `Required<Type>` is assignable to type `Type`
+
+  let assignabilityCheck1: <Type>(object: Type) => object is Required<Type>;
+
+  // it verifies that type `MarkRequired<Type, PropertyName>`
+  // is assignable to type `Type`
+
+  let assignabilityCheck2: <Type, PropertyName extends keyof Type>(
+    object: Type,
+    propertyNames: PropertyName[],
+  ) => object is MarkRequired<Type, PropertyName>;
 }

--- a/test/mark-writable.ts
+++ b/test/mark-writable.ts
@@ -12,23 +12,13 @@ type Example = {
 };
 
 function testMarkWritable() {
+  type ExampleWithWritableReadonly1 = Debug<MarkWritable<Example, "readonly1">>;
+
   type cases = [
     Assert<IsExact<MarkWritable<Example, never>, Example>>,
     Assert<IsExact<MarkWritable<Example, WritableKeys<Example>>, Example>>,
     Assert<IsExact<MarkWritable<Example, ReadonlyKeys<Example>>, Writable<Example>>>,
-    Assert<
-      IsExact<
-        MarkWritable<Example, "readonly1">,
-        {
-          readonly1: Date;
-          readonly readonly2: RegExp;
-          required1: number;
-          required2: string;
-          optional1?: null;
-          optional2?: boolean;
-        }
-      >
-    >,
+    Assert<IsExact<ReadonlyKeys<ExampleWithWritableReadonly1>, "readonly2">>,
     // @ts-expect-error do NOT support union types
     MarkWritable<Example | { a: 1 }, "readonly1">,
   ];
@@ -36,17 +26,17 @@ function testMarkWritable() {
 
 function testUnionTypes() {
   type UnionExample = Debug<
-    MarkWritable<Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">, "optional1">
+    MarkWritable<Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly1" | "optional2">, "readonly1">
   >;
 
   let unionElementFields: UnionExample = {
-    readonly2: /\w+/g,
+    readonly1: new Date(),
     optional1: null,
   };
 
   unionElementFields = {
     readonly1: new Date(),
-    optional1: null,
+    optional2: true,
   };
 }
 

--- a/test/mark-writable.ts
+++ b/test/mark-writable.ts
@@ -1,31 +1,17 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
 import { MarkWritable, Writable, ReadonlyKeys, WritableKeys } from "../lib";
+import { Debug } from "./types";
+
+type Example = {
+  readonly readonly1: Date;
+  readonly readonly2: RegExp;
+  required1: number;
+  required2: string;
+  optional1?: null;
+  optional2?: boolean;
+};
 
 function testMarkWritable() {
-  type Example = {
-    readonly readonly1: Date;
-    readonly readonly2: RegExp;
-    required1: number;
-    required2: string;
-    optional1?: null;
-    optional2?: boolean;
-  };
-
-  type UnionExample = MarkWritable<
-    Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">,
-    "optional1"
-  >;
-
-  let unionElementFields: UnionExample = {
-    readonly2: /\w+/g,
-    optional1: null,
-  };
-
-  unionElementFields = {
-    readonly1: new Date(),
-    optional1: null,
-  };
-
   type cases = [
     Assert<IsExact<MarkWritable<Example, never>, Example>>,
     Assert<IsExact<MarkWritable<Example, WritableKeys<Example>>, Example>>,
@@ -46,4 +32,43 @@ function testMarkWritable() {
     // @ts-expect-error do NOT support union types
     MarkWritable<Example | { a: 1 }, "readonly1">,
   ];
+}
+
+function testUnionTypes() {
+  type UnionExample = Debug<
+    MarkWritable<Pick<Example, "readonly1" | "optional1"> | Pick<Example, "readonly2" | "optional1">, "optional1">
+  >;
+
+  let unionElementFields: UnionExample = {
+    readonly2: /\w+/g,
+    optional1: null,
+  };
+
+  unionElementFields = {
+    readonly1: new Date(),
+    optional1: null,
+  };
+}
+
+declare let example: Example;
+declare let writableExample: Writable<Example>;
+declare let markedWritableExample: Debug<MarkWritable<Example, "readonly1">>;
+
+function testAssignability() {
+  example = writableExample;
+  example = markedWritableExample;
+  writableExample = example;
+  markedWritableExample = example;
+
+  // it verifies that type `Writable<Type>` is assignable to type `Type`
+
+  let assignabilityCheck1: <Type>(object: Type) => object is Writable<Type>;
+
+  // it verifies that type `MarkWritable<Type, PropertyName>`
+  // is assignable to type `Type`
+
+  let assignabilityCheck2: <Type, PropertyName extends keyof Type>(
+    object: Type,
+    propertyNames: PropertyName[],
+  ) => object is MarkWritable<Type, PropertyName>;
 }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,3 +1,5 @@
+export type Debug<Type> = { [Key in keyof Type]: Type[Key] } & {};
+
 export type ComplexNestedRequired = {
   simple: number;
   nested: {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to #349
- [ ] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Assignability of Mark* utility types, e.g. `MarkRequired` should be identical to its builtin type `Required`

- Added `Debug` type for tests
- Added assignability checks – https://github.com/ts-essentials/ts-essentials/commit/ef16a24f37a822c1f51b03b2253322dce39dafe3
- Fixed 3 utility types `MarkRequired`, `MarkReadonly` and `MarkWritable`
