### PR TITLE
fix: support types extending Array in DeepRequired

### DIFF
--- a/.changeset/silly-buses-camp.md
+++ b/.changeset/silly-buses-camp.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Add support for types which explicitly extend Array inside types passed to `DeepRequired`.

--- a/lib/deep-required/index.ts
+++ b/lib/deep-required/index.ts
@@ -1,4 +1,5 @@
 import { Builtin } from "../built-in";
+import { IsTuple } from "../is-tuple";
 
 export type DeepRequired<Type> = Type extends Error
   ? Required<Type>
@@ -18,6 +19,12 @@ export type DeepRequired<Type> = Type extends Error
   ? WeakSet<DeepRequired<Values>>
   : Type extends Promise<infer Value>
   ? Promise<DeepRequired<Value>>
+  : Type extends ReadonlyArray<infer Values>
+  ? Type extends IsTuple<Type>
+    ? { [Key in keyof Type]-?: DeepRequired<Type[Key]> }
+    : Type extends Array<Values>
+    ? Array<Exclude<DeepRequired<Values>, undefined>>
+    : ReadonlyArray<Exclude<DeepRequired<Values>, undefined>>
   : Type extends {}
   ? { [Key in keyof Type]-?: DeepRequired<Type[Key]> }
   : Required<Type>;

--- a/test/deep-required.ts
+++ b/test/deep-required.ts
@@ -19,6 +19,10 @@ function testDeepRequired() {
     caseSensitive: true;
   }
 
+  interface ExtendedArray<T> extends Array<T> {}
+
+  interface ExtendedReadonlyArray<T> extends ReadonlyArray<T> {}
+
   type cases = [
     Assert<IsExact<DeepRequired<number | null | undefined>, number | null | undefined>>,
     Assert<IsExact<DeepRequired<string | null | undefined>, string | null | undefined>>,
@@ -89,6 +93,9 @@ function testDeepRequired() {
     >,
     Assert<IsExact<DeepRequired<readonly (number | null | undefined)[]>, readonly (number | null)[]>>,
     Assert<IsExact<DeepRequired<Array<number | null | undefined>>, Array<number | null>>>,
+    Assert<IsExact<DeepRequired<ReadonlyArray<number | null | undefined>>, ReadonlyArray<number | null>>>,
+    Assert<IsExact<DeepRequired<ExtendedArray<number | null | undefined>>, Array<number | null>>>,
+    Assert<IsExact<DeepRequired<ExtendedReadonlyArray<number | null | undefined>>, ReadonlyArray<number | null>>>,
     Assert<IsExact<DeepRequired<Promise<number | null | undefined>>, Promise<number | null | undefined>>>,
     Assert<
       IsExact<


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: related to #366
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

Work-in-progress attempt to fix #366. See comments inline.
