### PR TITLE
chore(deps): mark typescript as optional

### DIFF
--- a/.changeset/early-students-brush.md
+++ b/.changeset/early-students-brush.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": minor
+---
+
+Make `typescript` optional as a peer dependency

--- a/README.md
+++ b/README.md
@@ -225,13 +225,14 @@ facilitate common type transformations. These utilities are available globally.
 
 ## TypeScript dependency table
 
-| `ts-essentials` | `typescript` / type of dependency |
-| --------------- | --------------------------------- |
-| `^8.0.0`        | `^4.1.0` / peer                   |
-| `^5.0.0`        | `^3.7.0` / peer                   |
-| `^3.0.1`        | `^3.5.0` / peer                   |
-| `^1.0.1`        | `^3.2.2` / dev                    |
-| `^1.0.0`        | `^3.0.3` / dev                    |
+| `ts-essentials` | `typescript` / type of dependency                                                     |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `^9.4.0`        | `^4.1.0` / [peer optional](https://github.com/ts-essentials/ts-essentials/issues/370) |
+| `^8.0.0`        | `^4.1.0` / peer                                                                       |
+| `^5.0.0`        | `^3.7.0` / peer                                                                       |
+| `^3.0.1`        | `^3.5.0` / peer                                                                       |
+| `^1.0.1`        | `^3.2.2` / dev                                                                        |
+| `^1.0.0`        | `^3.0.3` / dev                                                                        |
 
 ## Contributors
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
   "peerDependencies": {
     "typescript": ">=4.1.0"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@changesets/cli": "^2.11.2",
     "@codechecks/build-size-watcher": "^0.1.0",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to #370
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This marks `typescript` as optional so that JS-only apps may import code from libraries dependent upon ts-essentials without having to install TypeScript.

The version constraint for consumers using `typescript` would still apply.
