### PR TITLE
docs: fix the anchor link on README for TypeScript dependency table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save-dev ts-essentials
 ```
 
 👉 We require `typescript>=4.1`. If you're looking for support for older TS versions, please have a look at the
-[TypeScript dependency table](https://github.com/ts-essentials/ts-essentials/tree/master#TypeScript-dependency-table)
+[TypeScript dependency table](#typescript-dependency-table)
 
 👉 As we really want types to be stricter, we require enabled
 [strictNullChecks](https://www.typescriptlang.org/tsconfig#strictNullChecks) in your project


### PR DESCRIPTION
Thanks for the great library!

<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] ~~Addresses an existing open issue: related to #000~~
  - Because fixing a minor typo on README, this change is not related to any issues
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

In the `install` section on README, the anchor link for `TypeScript dependency table` is not working because some words are capitalized.
So I fixed it correctly. 

You can also check the fix with the following videos.

### AFTER

https://github.com/ts-essentials/ts-essentials/assets/50320710/39416b1e-b273-4e70-88ee-baa604c6d034

### BEFORE (CURRENT)

https://github.com/ts-essentials/ts-essentials/assets/50320710/96146d2d-8168-494a-ae63-e244a8f96a7c




