### PR TITLE
ci: ➕ Add compatibility versions of 5.0, 5.1 and 5.2 typescript versions

### DIFF
--- a/.changeset/weak-llamas-lick.md
+++ b/.changeset/weak-llamas-lick.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix regression in TypeScript 5.1 with CamelCase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['10.x']
+        node: ["14.x"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
@@ -35,7 +35,6 @@ jobs:
       - run: yarn codechecks
         env:
           CC_SECRET: ${{ secrets.CC_SECRET }}
-
 # Few tips github actions
 # - name: Setup SSH debug session
 #   uses: mxschmitt/action-tmate@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: "14.x"
 
       - name: Cache YARN dependencies
         uses: actions/cache@v2

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,9 +11,10 @@ jobs:
     name: TypeScript ${{ matrix.typescript }}
     strategy:
       matrix:
-        node: ['10.x']
+        node: ["10.x"]
         os: [ubuntu-latest]
-        typescript: ['4.1.5', '4.2.4', '4.3.5', '4.4.4', '4.5.5', '4.6.4', '4.7.4', '4.8.4', '4.9.4']
+        typescript:
+          ["4.1.5", "4.2.4", "4.3.5", "4.4.4", "4.5.5", "4.6.4", "4.7.4", "4.8.4", "4.9.4", "5.0.4", "5.1.6", "5.2.2"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,7 +11,7 @@ jobs:
     name: TypeScript ${{ matrix.typescript }}
     strategy:
       matrix:
-        node: ["10.x"]
+        node: ["14.x"]
         os: [ubuntu-latest]
         typescript:
           ["4.1.5", "4.2.4", "4.3.5", "4.4.4", "4.5.5", "4.6.4", "4.7.4", "4.8.4", "4.9.4", "5.0.4", "5.1.6", "5.2.2"]

--- a/lib/camel-case/index.ts
+++ b/lib/camel-case/index.ts
@@ -1,12 +1,10 @@
 type IsStringLiteral<Type> = Type extends string ? (string extends Type ? false : true) : false;
 
-type WordInPascalCase<Type> = Capitalize<WordInCamelCase<Uncapitalize<Type & string>>>;
-
-type WordInCamelCase<Type, Character extends string = ""> = Type extends `${Character}${infer NextCharacter}${infer _}`
+type WordInCamelCase<Type, Word extends string = ""> = Type extends `${Word}${infer NextCharacter}${infer _}`
   ? NextCharacter extends Capitalize<NextCharacter>
-    ? Character
-    : WordInCamelCase<Type, `${Character}${NextCharacter}`>
-  : Character;
+    ? Word
+    : WordInCamelCase<Type, `${Word}${NextCharacter}`>
+  : Word;
 
 type Separator = "_" | "-";
 
@@ -34,19 +32,14 @@ type SeparatorCaseParser<
 
 type CamelCaseParser<Type, Tuple extends readonly any[] = []> = Type extends ""
   ? Tuple
-  : Type extends `${WordInCamelCase<Type & string>}${infer Tail}`
+  : Type extends `${WordInCamelCase<Type>}${infer Tail}`
   ? Type extends `${infer Word}${Tail}`
     ? CamelCaseParser<Uncapitalize<Tail>, [...Tuple, Lowercase<Word>]>
     : never
   : never;
 
-type PascalCaseParser<Type, Tuple extends readonly any[] = []> = Type extends ""
-  ? Tuple
-  : Type extends `${WordInPascalCase<Type & string>}${infer Tail}`
-  ? Type extends `${infer Word}${Tail}`
-    ? PascalCaseParser<Tail, [...Tuple, Lowercase<Word>]>
-    : never
-  : never;
+// Convert first character of string literal type to lowercase and reuse CamelCaseParser
+type PascalCaseParser<Type> = Type extends string ? CamelCaseParser<Uncapitalize<Type>> : never;
 
 type SplitAnyCase<Type> = IncludesSeparator<Type> extends true
   ? SeparatorCaseParser<Type>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to https://github.com/ts-essentials/ts-essentials/issues/365
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

- Added TypeScript 5.0, 5.1 & 5.2 to CI for typecheck
- Used node 14 on CI
- Fix regression in TypeScript 5.1 with CamelCase (iteration step was infinite because of taking a substring as empty string)
