### PR TITLE
Use key remapping from Typescript 4.1 for PickProperties and OmitProperties

### DIFF
--- a/lib/omit-properties/index.ts
+++ b/lib/omit-properties/index.ts
@@ -1,3 +1,1 @@
-import { PickKeysByValue } from "../pick-keys-by-value";
-
-export type OmitProperties<Type, Value> = Omit<Type, PickKeysByValue<Type, Value>>;
+export type OmitProperties<Type, Value> = { [Key in keyof Type as Type[Key] extends Value ? never : Key]: Type[Key] };

--- a/lib/pick-keys-by-value.ts
+++ b/lib/pick-keys-by-value.ts
@@ -1,1 +1,0 @@
-export type PickKeysByValue<Type, Value> = { [Key in keyof Type]: Type[Key] extends Value ? Key : never }[keyof Type];

--- a/lib/pick-keys/index.ts
+++ b/lib/pick-keys/index.ts
@@ -1,3 +1,3 @@
 import { PickProperties } from "../pick-properties";
 
-export type PickKeys<Type, Value> = Exclude<keyof PickProperties<Type, Value>, undefined>;
+export type PickKeys<Type, Value> = keyof PickProperties<Type, Value>;

--- a/lib/pick-properties/index.ts
+++ b/lib/pick-properties/index.ts
@@ -1,3 +1,3 @@
-import { PickKeysByValue } from "../pick-keys-by-value";
-
-export type PickProperties<Type, Value> = Pick<Type, PickKeysByValue<Type, Value>>;
+export type PickProperties<Type, Value> = {
+  [Key in keyof Type as Type[Key] extends Value ? Key : never]: Type[Key];
+};

--- a/test/pick-keys.ts
+++ b/test/pick-keys.ts
@@ -1,6 +1,5 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
 import { PickKeys } from "../lib";
-import { TsVersion } from "./ts-version";
 
 function testPickKeys() {
   type cases = [
@@ -9,14 +8,14 @@ function testPickKeys() {
     // @ts-expect-error converts to String and gets `number | undefined` keys
     Assert<IsExact<PickKeys<string, number | undefined>, never>>,
     // wtf?
-    Assert<IsExact<PickKeys<boolean, number | undefined>, () => boolean>>,
+    Assert<IsExact<PickKeys<boolean, number | undefined>, "valueOf">>,
     // @ts-expect-error converts to BigInt and gets `number | undefined` keys
     Assert<IsExact<PickKeys<bigint, number | undefined>, never>>,
     // wtf?
     Assert<
       IsExact<
         PickKeys<symbol, number | undefined>,
-        string | ((hint: string) => symbol) | (() => string) | (() => symbol)
+        SymbolConstructor["toPrimitive"] | SymbolConstructor["toStringTag"] | "toString" | "valueOf"
       >
     >,
     Assert<IsExact<PickKeys<undefined, number | undefined>, never>>,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: related to #000
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview
I took advantage of [key remapping](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types) feature introduced starting from Typescript 4.1.

This allows to reduce the number of iterations when these types are used and to remove the utility PickKeysByValue.

In tests, the "wtf" cases continue to be a bit "wtf" but they are closer to be keys, at least.

I wanted to use this syntax for other cases, but it changes the behavior a bit more and, despite I think it would be reasonable the new behavior, it requires more discussion.
