### PR TITLE
feat: deprecate DictionaryValues

### DIFF
--- a/.changeset/rich-badgers-learn.md
+++ b/.changeset/rich-badgers-learn.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Deprecated `DictionaryValues` in favour of `ValueOf`

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ node_modules
 .vscode
 package.json
 dist
+# Alerts markdown syntax is incorrectly formatted
+**/*.md

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ npm install --save-dev ts-essentials
 - [`AsyncOrSyncType<Type>`](/lib/async-or-sync-type) - Unwraps `AsyncOrSync` type
 - [`Dictionary<Type, Keys?>`](/lib/dictionary) - Constructs a required object type which property keys are `Keys`
   (`string` by default) and which property values are `Type`
-- [`DictionaryValues<Type>`](/lib/dictionary-values) - This type unwraps `Dictionary` value type
 - [`Merge<Object1, Object2>`](/lib/merge) - Constructs a type by picking all properties from `Object1` and `Object2`.
   Property values from `Object2` override property values from `Object1` when property keys are the same
 - [`MergeN<Tuple>`](/lib/merge-n) - Constructs a type by merging objects with type `Merge` in tuple `Tuple` recursively
@@ -212,6 +211,7 @@ When one of utility types is known by a different name, kindly ask adding it her
 - `Nominal` - [`Opaque<Type, Token>`](/lib/opaque)
 - `Set*`, e.g. `SetOptional` - `Mark*`, e.g. [`MarkReadonly<Type, Keys>`](/lib/mark-readonly)
 - `Unwrap` - [`Prettify<Type>`](/lib/prettify/)
+- `ValueOf` - `DictionaryValues`
 
 ## Built-in types
 

--- a/example/types.ts
+++ b/example/types.ts
@@ -1,6 +1,6 @@
-import { Dictionary, DictionaryValues, DeepPartial, DeepReadonly, Opaque, DeepRequired, AsyncOrSync } from "../lib";
+import { Dictionary, DeepPartial, DeepReadonly, Opaque, DeepRequired, AsyncOrSync, ValueOf } from "../lib";
 
-const stringDict: Dictionary<string> = {
+const stringObj: Dictionary<string> = {
   a: "A",
   b: "B",
 };
@@ -19,8 +19,8 @@ const dictFromUnionType: Dictionary<number, DummyOptions> = {
   unknown: 3,
 };
 
-// and get dictionary values
-type stringDictValues = DictionaryValues<typeof stringDict>;
+// and get object values
+type stringObjValues = ValueOf<typeof stringObj>;
 
 type ComplexObject = {
   simple: number;

--- a/lib/dictionary-values/README.md
+++ b/lib/dictionary-values/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> `DictionaryValues` is deprecated, please use [ValueOf](../value-of/) instead
+
 `DictionaryValues<Type>` unwraps `Dictionary` value type:
 
 ```ts

--- a/lib/dictionary-values/index.ts
+++ b/lib/dictionary-values/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @deprecated please use `ValueOf` instead
+ */
 export type DictionaryValues<Type> = Type[keyof Type];

--- a/lib/value-of/README.md
+++ b/lib/value-of/README.md
@@ -34,7 +34,7 @@ type IdentityFunctionValue = ValueOf<typeof identity>;
 //   ^? unknown
 ```
 
-3. The object property values for objects (like [`DictionaryValues<Type>`](../dictionary-values))
+3. The object property values for objects
 
 ```ts
 interface User {

--- a/test/index.ts
+++ b/test/index.ts
@@ -10,7 +10,6 @@ import {
   DeepNullable,
   DeepReadonly,
   Dictionary,
-  DictionaryValues,
   noop,
   PickProperties,
   ReadonlyKeys,
@@ -39,7 +38,6 @@ import {
   KeyofBase,
 } from "../lib";
 import { ComplexNestedPartial, ComplexNestedRequired } from "./types";
-import { TsVersion } from "./ts-version";
 
 function testDictionary() {
   type cases = [
@@ -60,53 +58,6 @@ function testDictionary() {
     Assert<IsExact<Dictionary<number, "a" | "b">["a"], number>>,
     Assert<IsExact<Dictionary<number, "a" | "b">["b"], number>>,
     Assert<IsExact<Dictionary<number, KeyofBase>[symbol], number>>,
-  ];
-}
-
-function testDictionaryValues() {
-  type cases = [
-    Assert<IsExact<DictionaryValues<Dictionary<string>>, string>>,
-    Assert<IsExact<DictionaryValues<Dictionary<number>>, number>>,
-    Assert<IsExact<DictionaryValues<Dictionary<boolean>>, boolean>>,
-    Assert<IsExact<DictionaryValues<Dictionary<bigint>>, bigint>>,
-    Assert<IsExact<DictionaryValues<Dictionary<symbol>>, symbol>>,
-    Assert<IsExact<DictionaryValues<Dictionary<undefined>>, undefined>>,
-    Assert<IsExact<DictionaryValues<Dictionary<null>>, null>>,
-    Assert<IsExact<DictionaryValues<Dictionary<string, "a" | "b">>, string>>,
-    Assert<IsExact<DictionaryValues<Dictionary<number, "a" | "b">>, number>>,
-    Assert<IsExact<DictionaryValues<Dictionary<boolean, "a" | "b">>, boolean>>,
-    Assert<IsExact<DictionaryValues<Dictionary<bigint, "a" | "b">>, bigint>>,
-    Assert<IsExact<DictionaryValues<Dictionary<symbol, "a" | "b">>, symbol>>,
-    Assert<IsExact<DictionaryValues<Dictionary<undefined, "a" | "b">>, undefined>>,
-    Assert<IsExact<DictionaryValues<Dictionary<null, "a" | "b">>, null>>,
-    Assert<IsExact<DictionaryValues<Dictionary<string, 1 | 2>>, string>>,
-    Assert<IsExact<DictionaryValues<Dictionary<number, 1 | 2>>, number>>,
-    Assert<IsExact<DictionaryValues<Dictionary<boolean, 1 | 2>>, boolean>>,
-    Assert<IsExact<DictionaryValues<Dictionary<bigint, 1 | 2>>, bigint>>,
-    Assert<IsExact<DictionaryValues<Dictionary<symbol, 1 | 2>>, symbol>>,
-    Assert<IsExact<DictionaryValues<Dictionary<undefined, 1 | 2>>, undefined>>,
-    Assert<IsExact<DictionaryValues<Dictionary<null, 1 | 2>>, null>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<string>>, string | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<number>>, number | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<boolean>>, boolean | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<bigint>>, bigint | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<symbol>>, symbol | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<undefined>>, undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<null>>, null | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<string, "a" | "b">>, string | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<number, "a" | "b">>, number | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<boolean, "a" | "b">>, boolean | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<bigint, "a" | "b">>, bigint | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<symbol, "a" | "b">>, symbol | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<undefined, "a" | "b">>, undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<null, "a" | "b">>, null | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<string, 1 | 2>>, string | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<number, 1 | 2>>, number | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<boolean, 1 | 2>>, boolean | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<bigint, 1 | 2>>, bigint | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<symbol, 1 | 2>>, symbol | undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<undefined, 1 | 2>>, undefined>>,
-    Assert<IsExact<DictionaryValues<SafeDictionary<null, 1 | 2>>, null | undefined>>,
   ];
 }
 

--- a/test/value-of.ts
+++ b/test/value-of.ts
@@ -1,5 +1,5 @@
 ﻿import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
-import { ValueOf, Primitive, AnyArray } from "../lib";
+import { ValueOf, Primitive, AnyArray, Dictionary, SafeDictionary } from "../lib";
 
 declare const array: number[];
 declare const func: (...arg: any[]) => boolean;
@@ -47,5 +47,55 @@ function testValueOf() {
     Assert<IsExact<ValueOf<number[] | string | null>, number | string | null>>,
     Assert<IsExact<ValueOf<boolean[] | typeof writableObj>, boolean | ValueOf<typeof writableObj>>>,
     Assert<IsExact<ValueOf<[string, number] | { keyA: bigint; keyB: null }>, string | number | bigint | null>>,
+  ];
+}
+
+// Moving unit tests in the scope of `ValueOf` since `DictionaryValues` is
+// deprecated in favour of `ValueOf`
+
+function testDictionaryValues() {
+  type cases = [
+    Assert<IsExact<ValueOf<Dictionary<string>>, string>>,
+    Assert<IsExact<ValueOf<Dictionary<number>>, number>>,
+    Assert<IsExact<ValueOf<Dictionary<boolean>>, boolean>>,
+    Assert<IsExact<ValueOf<Dictionary<bigint>>, bigint>>,
+    Assert<IsExact<ValueOf<Dictionary<symbol>>, symbol>>,
+    Assert<IsExact<ValueOf<Dictionary<undefined>>, undefined>>,
+    Assert<IsExact<ValueOf<Dictionary<null>>, null>>,
+    Assert<IsExact<ValueOf<Dictionary<string, "a" | "b">>, string>>,
+    Assert<IsExact<ValueOf<Dictionary<number, "a" | "b">>, number>>,
+    Assert<IsExact<ValueOf<Dictionary<boolean, "a" | "b">>, boolean>>,
+    Assert<IsExact<ValueOf<Dictionary<bigint, "a" | "b">>, bigint>>,
+    Assert<IsExact<ValueOf<Dictionary<symbol, "a" | "b">>, symbol>>,
+    Assert<IsExact<ValueOf<Dictionary<undefined, "a" | "b">>, undefined>>,
+    Assert<IsExact<ValueOf<Dictionary<null, "a" | "b">>, null>>,
+    Assert<IsExact<ValueOf<Dictionary<string, 1 | 2>>, string>>,
+    Assert<IsExact<ValueOf<Dictionary<number, 1 | 2>>, number>>,
+    Assert<IsExact<ValueOf<Dictionary<boolean, 1 | 2>>, boolean>>,
+    Assert<IsExact<ValueOf<Dictionary<bigint, 1 | 2>>, bigint>>,
+    Assert<IsExact<ValueOf<Dictionary<symbol, 1 | 2>>, symbol>>,
+    Assert<IsExact<ValueOf<Dictionary<undefined, 1 | 2>>, undefined>>,
+    Assert<IsExact<ValueOf<Dictionary<null, 1 | 2>>, null>>,
+    Assert<IsExact<ValueOf<SafeDictionary<string>>, string | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<number>>, number | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<boolean>>, boolean | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<bigint>>, bigint | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<symbol>>, symbol | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<undefined>>, undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<null>>, null | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<string, "a" | "b">>, string | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<number, "a" | "b">>, number | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<boolean, "a" | "b">>, boolean | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<bigint, "a" | "b">>, bigint | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<symbol, "a" | "b">>, symbol | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<undefined, "a" | "b">>, undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<null, "a" | "b">>, null | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<string, 1 | 2>>, string | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<number, 1 | 2>>, number | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<boolean, 1 | 2>>, boolean | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<bigint, 1 | 2>>, bigint | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<symbol, 1 | 2>>, symbol | undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<undefined, 1 | 2>>, undefined>>,
+    Assert<IsExact<ValueOf<SafeDictionary<null, 1 | 2>>, null | undefined>>,
   ];
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

- Deprecated `DictionaryValues`
- Removed `DictionaryValues` from docs
- Move unit tests to `ValueOf`