### PR TITLE
feat(Paths): Add optional `anyArrayIndexAccessor`

### DIFF
--- a/.changeset/slow-dolphins-fetch.md
+++ b/.changeset/slow-dolphins-fetch.md
@@ -1,0 +1,6 @@
+---
+"ts-essentials": patch
+---
+
+Add `Paths<Type, { anyArrayIndexAccessor: '*' }>`, a string literal representing a catch-all or "wildcard" when indexing
+on arrays.

--- a/lib/paths/README.md
+++ b/lib/paths/README.md
@@ -16,6 +16,16 @@ It supports:
 - Object types
 - Tuples
 - As a side effect of `number`, float number access for arrays
+- Wildcard array indices (opt-in)
+
+An optional symbol may be specified that will satisfy any array index
+
+```ts
+type WildcardCompanyPaths = Paths<Company, { anyArrayIndexAccessor: "*" }>;
+
+const anyEmployee: WildcardCompanyPaths = 'employees.*';
+const anyEmployeeName: WildcardCompanyPaths = 'employees.*.name';
+```
 
 ⚠️ Limitations:
 

--- a/lib/paths/index.ts
+++ b/lib/paths/index.ts
@@ -27,18 +27,25 @@ type RecursivePathsOptions = {
  * majority of use cases. If by any chance it doesn't fit you, feel free to
  * increase the value. However, this may increase the chance of getting
  * `Type instantiation is excessively deep and possibly infinite` error.
+ *
+ * @param anyArrayIndexAccessor By default there is no wildcard access to
+ * array indices - usage must be intentionally configured.
  */
 type DefaultPathsOptions = {
   depth: 7;
+  anyArrayIndexAccessor: `${number}`;
 };
 
 /**
  * @param depth This option restricts the depth of the paths lookup and removes `Type
  * instantiation is excessively deep and possibly infinite` errors for
  * potentially infinite types.
+ *
+ * @param anyArrayIndexAccessor This wildcard will satisfy any array index if defined.
  */
 type PathsOptions = {
   depth: number;
+  anyArrayIndexAccessor: string;
 };
 
 type Append<Tuple extends any[]> = [...Tuple, 0];
@@ -54,7 +61,7 @@ type RecursivePaths<
       ValueOf<{
         [Key in keyof Type]: Key extends Pathable
           ?
-              | `${Key}`
+              | `${AnyArrayIndexAccessorOrKey<Key, UserOptions>}`
               | (CallOptions["depth"]["length"] extends UserOptions["depth"]
                   ? // Stop at the configured depth
                     never
@@ -72,7 +79,7 @@ type RecursivePaths<
                         ? IsNever<Rest> extends true
                           ? never
                           : Rest extends Pathable
-                          ? `${Key}.${Rest}`
+                          ? `${AnyArrayIndexAccessorOrKey<Key, UserOptions>}.${Rest}`
                           : never
                         : never
                       : never
@@ -95,6 +102,10 @@ type UnsafePaths<Type, Options extends Required<PathsOptions>> = Type extends Ty
     ? RecursivePaths<Type, Options, DefaultRecursivePathsOptions>
     : never
   : never;
+
+type AnyArrayIndexAccessorOrKey<Key extends Pathable, UserOptions extends Required<PathsOptions>> = Key extends number
+  ? Key | UserOptions["anyArrayIndexAccessor"]
+  : Key;
 
 export type Paths<Type, OverridePathOptions extends Partial<PathsOptions> = {}> = UnsafePaths<
   Type,

--- a/test/paths.ts
+++ b/test/paths.ts
@@ -186,3 +186,31 @@ function testDepth2() {
     Assert<Assignable<P, "nested.tuple.2.good">>,
   ];
 }
+
+/**
+ * Configuration allows wildcard accessors for array indices.
+ */
+function testAnyArrayIndexAccessor() {
+  type With = Paths<ComplexNestedRequired, { anyArrayIndexAccessor: "*" }>;
+  type Without = Paths<ComplexNestedRequired>;
+
+  type cases_with_any_accessor = [
+    Assert<Has<With, "nested.array.*">>,
+    Assert<Has<With, "nested.array.*.bar">>,
+    Assert<Has<With, `nested.array.${number}`>>,
+    Assert<Has<With, `nested.array.${number}.bar`>>,
+    Assert<Has<With, "nested.tuple.0">>,
+    Assert<Has<With, "nested.tuple.2.good">>,
+    // @ts-expect-error: tuples should not be wildcard-able
+    Assert<Has<With, "nested.tuple.*">>,
+    // @ts-expect-error: tuples should not be wildcard-able
+    Assert<Has<With, "nested.tuple.*.good">>,
+  ];
+
+  type cases_without_any_accessor = [
+    // @ts-expect-error: anyArrayIndexAccessor is not configured
+    Assert<Has<Without, "nested.array.*">>,
+    // @ts-expect-error: anyArrayIndexAccessor is not configured
+    Assert<Has<Without, "nested.array.*.bar">>,
+  ];
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to 
    - resolves: #411
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Adds optional configuration that allows wildcards to satisfy array index access.