### PR TITLE
Fix: Behaviour of `OptionalKeys` when instantiated with primitives and arrays

### DIFF
--- a/.changeset/ninety-forks-poke.md
+++ b/.changeset/ninety-forks-poke.md
@@ -2,4 +2,4 @@
 "ts-essentials": patch
 ---
 
-Fix `OptionalKeys<Type>`, it now works as expected with primitives and arrays
+`OptionalKeys<Type>` returns `never` for primitives and returns only optional indices for arrays and tuples

--- a/.changeset/ninety-forks-poke.md
+++ b/.changeset/ninety-forks-poke.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `OptionalKeys<Type>`, it now works as expected with primitives and arrays

--- a/lib/optional-keys/index.ts
+++ b/lib/optional-keys/index.ts
@@ -1,5 +1,5 @@
 export type OptionalKeys<Type> = Type extends unknown
   ? {
-      [Key in Exclude<keyof Type, never>]-?: undefined extends { [Key2 in keyof Type]: Key2 }[Key] ? Key : never;
+      [Key in Exclude<keyof Type, never>]-?: undefined extends { [Key2 in keyof Type]: never }[Key] ? Key : never;
     }[keyof Type]
   : never;

--- a/lib/optional-keys/index.ts
+++ b/lib/optional-keys/index.ts
@@ -1,5 +1,5 @@
 export type OptionalKeys<Type> = Type extends unknown
   ? {
-      [Key in keyof Type]-?: undefined extends { [Key2 in keyof Type]: Key2 }[Key] ? Key : never;
+      [Key in Exclude<keyof Type, never>]-?: undefined extends { [Key2 in keyof Type]: Key2 }[Key] ? Key : never;
     }[keyof Type]
   : never;

--- a/lib/optional-keys/index.ts
+++ b/lib/optional-keys/index.ts
@@ -1,5 +1,5 @@
 export type OptionalKeys<Type> = Type extends object
-  ? {
-      [Key in keyof Type]-?: Type extends Required<Pick<Type, Key>> ? never : Key;
-    }[keyof Type & (Type extends ReadonlyArray<any> ? number : keyof Type)]
+  ? keyof {
+      [Key in keyof Type as Type extends Required<Pick<Type, Key>> ? never : Key]: any;
+    }
   : never;

--- a/lib/optional-keys/index.ts
+++ b/lib/optional-keys/index.ts
@@ -1,5 +1,5 @@
 export type OptionalKeys<Type> = Type extends object
   ? {
-      [Key in keyof Type]-?: undefined extends { [Key2 in keyof Type]: never }[Key] ? Key : never;
+      [Key in keyof Type]-?: Type extends Required<Pick<Type, Key>> ? never : Key;
     }[keyof Type & (Type extends ReadonlyArray<any> ? number : keyof Type)]
   : never;

--- a/lib/optional-keys/index.ts
+++ b/lib/optional-keys/index.ts
@@ -1,5 +1,5 @@
-export type OptionalKeys<Type> = Type extends unknown
+export type OptionalKeys<Type> = Type extends object
   ? {
-      [Key in Exclude<keyof Type, never>]-?: undefined extends { [Key2 in keyof Type]: never }[Key] ? Key : never;
-    }[keyof Type]
+      [Key in keyof Type]-?: undefined extends { [Key2 in keyof Type]: never }[Key] ? Key : never;
+    }[keyof Type & (Type extends ReadonlyArray<any> ? number : keyof Type)]
   : never;

--- a/test/index.ts
+++ b/test/index.ts
@@ -457,22 +457,23 @@ function testPickProperties() {
 
 function testOptionalKeys() {
   type cases = [
-    // @ts-expect-error converts to Number and gets its optional keys
     Assert<IsExact<OptionalKeys<number>, never>>,
-    // @ts-expect-error converts to String and gets its optional keys
     Assert<IsExact<OptionalKeys<string>, never>>,
-    // wtf?
-    Assert<IsExact<OptionalKeys<boolean>, () => boolean>>,
-    // @ts-expect-error converts to BigInt and gets its optional keys
+    Assert<IsExact<OptionalKeys<boolean>, never>>,
     Assert<IsExact<OptionalKeys<bigint>, never>>,
-    // wtf?
-    Assert<IsExact<OptionalKeys<symbol>, string | ((hint: string) => symbol) | (() => string) | (() => symbol)>>,
+    Assert<IsExact<OptionalKeys<symbol>, never>>,
     Assert<IsExact<OptionalKeys<undefined>, never>>,
     Assert<IsExact<OptionalKeys<null>, never>>,
     Assert<IsExact<OptionalKeys<Function>, never>>,
     Assert<IsExact<OptionalKeys<Date>, never>>,
     Assert<IsExact<OptionalKeys<Error>, "stack">>,
     Assert<IsExact<OptionalKeys<RegExp>, never>>,
+    Assert<IsExact<OptionalKeys<() => void>, never>>,
+    Assert<IsExact<OptionalKeys<any[]>, never>>,
+    Assert<IsExact<OptionalKeys<[1, 2]>, never>>,
+    // function with optional property
+    Assert<IsExact<OptionalKeys<{ (): void; a?: 1 }>, "a">>,
+    Assert<IsExact<OptionalKeys<{ (): void; a: 1 }>, never>>,
     Assert<IsExact<OptionalKeys<{}>, never>>,
     Assert<IsExact<OptionalKeys<{ a: 1 }>, never>>,
     Assert<IsExact<OptionalKeys<{ a?: 1 }>, "a">>,
@@ -492,16 +493,22 @@ function testOptionalKeys() {
 function testRequiredKeys() {
   type cases = [
     Assert<IsExact<RequiredKeys<number>, keyof Number>>,
-    Assert<IsExact<RequiredKeys<string>, SymbolConstructor["iterator"]>>,
+    Assert<IsExact<RequiredKeys<string>, keyof string>>,
     Assert<IsExact<RequiredKeys<boolean>, keyof Boolean>>,
     Assert<IsExact<RequiredKeys<bigint>, keyof BigInt>>,
-    Assert<IsExact<RequiredKeys<symbol>, typeof Symbol.toPrimitive | typeof Symbol.toStringTag>>,
+    Assert<IsExact<RequiredKeys<symbol>, keyof symbol>>,
     Assert<IsExact<RequiredKeys<undefined>, never>>,
     Assert<IsExact<RequiredKeys<null>, never>>,
     Assert<IsExact<RequiredKeys<Function>, keyof Function>>,
     Assert<IsExact<RequiredKeys<Date>, keyof Date>>,
     Assert<IsExact<RequiredKeys<Error>, "name" | "message">>,
     Assert<IsExact<RequiredKeys<RegExp>, keyof RegExp>>,
+    Assert<IsExact<RequiredKeys<() => void>, never>>,
+    Assert<IsExact<RequiredKeys<any[]>, keyof any[]>>,
+    Assert<IsExact<RequiredKeys<[1, 2]>, keyof [1, 2]>>,
+    Assert<IsExact<RequiredKeys<{ (): void; a?: 1 }>, never>>,
+    // function with required property
+    Assert<IsExact<RequiredKeys<{ (): void; a: 1 }>, "a">>,
     Assert<IsExact<RequiredKeys<{}>, never>>,
     Assert<IsExact<RequiredKeys<{ a: 1 }>, "a">>,
     Assert<IsExact<RequiredKeys<{ a?: 1 }>, never>>,

--- a/test/index.ts
+++ b/test/index.ts
@@ -471,7 +471,7 @@ function testOptionalKeys() {
     Assert<IsExact<OptionalKeys<() => void>, never>>,
     Assert<IsExact<OptionalKeys<any[]>, never>>,
     Assert<IsExact<OptionalKeys<[1, 2]>, never>>,
-    // function with optional property
+    Assert<IsExact<OptionalKeys<[1, 2?]>, "1">>,
     Assert<IsExact<OptionalKeys<{ (): void; a?: 1 }>, "a">>,
     Assert<IsExact<OptionalKeys<{ (): void; a: 1 }>, never>>,
     Assert<IsExact<OptionalKeys<{}>, never>>,
@@ -507,8 +507,8 @@ function testRequiredKeys() {
     Assert<IsExact<RequiredKeys<any[]>, keyof any[]>>,
     Assert<IsExact<RequiredKeys<[1, 2]>, keyof [1, 2]>>,
     Assert<IsExact<RequiredKeys<{ (): void; a?: 1 }>, never>>,
-    // function with required property
     Assert<IsExact<RequiredKeys<{ (): void; a: 1 }>, "a">>,
+    Assert<IsExact<RequiredKeys<[1, 2?]>, Exclude<keyof [1, 2?], "1">>>,
     Assert<IsExact<RequiredKeys<{}>, never>>,
     Assert<IsExact<RequiredKeys<{ a: 1 }>, "a">>,
     Assert<IsExact<RequiredKeys<{ a?: 1 }>, never>>,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Currently, the `OptionalKeys` type doesn’t handle primitives and arrays as expected.

### Handling Primitives Correctly
Since `OptionalKeys` is a [homomorphic mapped type](https://github.com/microsoft/TypeScript/pull/26063), so when it’s instantiated with a primitive `Type`, it simply returns back `Type`. As a result, instantiating `OptionalKeys` with `string` yields `string[keyof string]`, which isn’t the intended result.

The fix here is straightforward, we simply bypass primitives by changing the conditional from `Type extends unknown` to `Type extends object`. So, when `OptionalKeys` is instantiated with primitives, the condition evaluates to false, returning `never` as expected.

### Handling Arrays Correctly
Ideally, `OptionalKeys<[1, 2?]>` should return `"1"`, but instead, it returns a bunch of unintended things.

Here's the existing code for reference:
```ts
export type OptionalKeys<Type> = Type extends unknown
  ? {
      [Key in keyof Type]-?: undefined extends { [Key2 in keyof Type]: Key2 }[Key] ? Key : never;
    }[keyof Type]
  : never;
```
Let's break down what happens when `OptionalKeys` is instantiated with `[1, 2?]`.

- Since the inner mapped type (`{ [Key2 in keyof Type]: Key2 }`) is homomorphic, it **correctly** preserves the tuple structure and evaluates to `[Key2, Key2?]` (Note: `Key2` is insignificant here; could have simply been `never` as well). Therefore, the conditional `undefined extends ...` evaluates to true only when `Key` is `"1"`.
- Consequently, because the outer mapped type is also homomorphic, it **correctly** evaluates to `[never, "1"]`.
- However, the problem arises when we try to do `[never, "1"][keyof T]` as this yields a bunch of unintended keys. Instead, if we index it with the `number` type, we get the desired result of "1".

The fix involves using `number` as the index for arrays instead of `keyof Type`.

### Additional Improvements & Tests:
1. Added a couple of more test cases to cover arrays and functions.
2. Replaced `Key2` with `never` in the inner mapped type for better readability. Using a specific type like `Key2` can imply that its value is being utilised, which isn’t the case here.