### PR TITLE
Fix: Failing `test:fix` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "formatDeclarations": "prettier --ignore-path *.js --write dist/*.d.ts",
     "prepublishOnly": "yarn test && yarn build && yarn formatDeclarations",
     "test": "node scripts/update-test-tsconfig.js && prettier -c {bench,lib,test}/**/*.ts && tsc --project tsconfig.test.json --outDir ./testDist && rimraf ./testDist",
-    "test:fix": "prettier --write {bench,lib,test}/**/*.ts",
+    "test:fix": "node scripts/update-test-tsconfig.js && prettier --write {bench,lib,test}/**/*.ts",
     "perf": "tsx ./bench/index.ts --benchErrorOnThresholdExceeded --benchPercentThreshold 1",
     "prerelease": "yarn test",
     "release": "yarn build && yarn formatDeclarations && yarn changeset publish",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "formatDeclarations": "prettier --ignore-path *.js --write dist/*.d.ts",
     "prepublishOnly": "yarn test && yarn build && yarn formatDeclarations",
     "test": "node scripts/update-test-tsconfig.js && prettier -c {bench,lib,test}/**/*.ts && tsc --project tsconfig.test.json --outDir ./testDist && rimraf ./testDist",
-    "test:fix": "prettier --write {bench,lib,test}/**/*.ts && tsc --project tsconfig.test.json --outDir ./testDist && rimraf ./testDist",
+    "test:fix": "prettier --write {bench,lib,test}/**/*.ts",
     "perf": "tsx ./bench/index.ts --benchErrorOnThresholdExceeded --benchPercentThreshold 1",
     "prerelease": "yarn test",
     "release": "yarn build && yarn formatDeclarations && yarn changeset publish",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [X] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
@Beraliv Here's a tiny PR.

Just realised that the `test:fix` script now fails because it doesn’t update `tsconfig.test.json`. This update is now required since even the locked TypeScript version (i.e., `4.9.5`) needs a few files to be excluded due to the changes made in [this PR](https://github.com/ts-essentials/ts-essentials/pull/416).

I've removed running tests from the `test:fix` script in this PR. However, if you feel we should not remove it, then we could do it like this:
```diff
- "test:fix": "prettier --write {bench,lib,test}/**/*.ts && tsc --project tsconfig.test.json --outDir ./testDist && rimraf ./testDist"
+ "test:fix": "prettier --write {bench,lib,test}/**/*.ts && yarn test"
```

<br />

And either ways, I think we should probably rename the script to `prettier:fix` because the script doesn't really fix any tests. WDYT?
