### PR TITLE
Fix: Make `MarkOptional<Type, Keys extends keyof Type>` assignable to `Partial<Type>`

### DIFF
--- a/.changeset/heavy-gorillas-march.md
+++ b/.changeset/heavy-gorillas-march.md
@@ -2,4 +2,4 @@
 "ts-essentials": patch
 ---
 
-`MarkOptional<Type, Keys extends keyof Type>` is now assignable to `Partial<Type>`
+`MarkOptional<Type, Keys>` is now assignable to `Partial<Type>`

--- a/.changeset/heavy-gorillas-march.md
+++ b/.changeset/heavy-gorillas-march.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+`MarkOptional<Type>` is now assignable to `Partial<Type>`

--- a/.changeset/heavy-gorillas-march.md
+++ b/.changeset/heavy-gorillas-march.md
@@ -2,4 +2,4 @@
 "ts-essentials": patch
 ---
 
-`MarkOptional<Type>` is now assignable to `Partial<Type>`
+`MarkOptional<Type, Keys extends keyof Type>` is now assignable to `Partial<Type>`

--- a/lib/mark-optional/index.ts
+++ b/lib/mark-optional/index.ts
@@ -1,5 +1,5 @@
 import { OptionalKeys } from "../optional-keys";
 
 export type MarkOptional<Type, Keys extends keyof Type> = Type extends Type
-  ? Partial<Type> & Required<Pick<Type, Exclude<keyof Type, Keys | OptionalKeys<Type & object>>>>
+  ? Partial<Type> & Required<Omit<Type, Keys | OptionalKeys<Type & object>>>
   : never;

--- a/lib/mark-optional/index.ts
+++ b/lib/mark-optional/index.ts
@@ -1,3 +1,5 @@
+import { OptionalKeys } from "../optional-keys";
+
 export type MarkOptional<Type, Keys extends keyof Type> = Type extends Type
-  ? Omit<Type, Keys> & Partial<Pick<Type, Keys>>
+  ? Partial<Type> & Required<Pick<Type, Exclude<keyof Type, Keys | OptionalKeys<Type & object>>>>
   : never;

--- a/lib/mark-optional/index.ts
+++ b/lib/mark-optional/index.ts
@@ -1,5 +1,5 @@
 import { OptionalKeys } from "../optional-keys";
 
 export type MarkOptional<Type, Keys extends keyof Type> = Type extends Type
-  ? Partial<Type> & Required<Omit<Type, Keys | OptionalKeys<Type & object>>>
+  ? Partial<Type> & Required<Omit<Type, Keys | OptionalKeys<Type>>>
   : never;

--- a/lib/mark-readonly/index.ts
+++ b/lib/mark-readonly/index.ts
@@ -2,6 +2,5 @@ import { ReadonlyKeys } from "../readonly-keys";
 import { Writable } from "../writable";
 
 export type MarkReadonly<Type, Keys extends keyof Type> = Type extends Type
-  ? Readonly<Type> &
-      Writable<Pick<Type, Exclude<keyof Type, Keys | (Type extends object ? ReadonlyKeys<Type> : never)>>>
+  ? Readonly<Type> & Writable<Omit<Type, Keys | ReadonlyKeys<Type & object>>>
   : never;

--- a/test/mark-optional.ts
+++ b/test/mark-optional.ts
@@ -55,6 +55,7 @@ function testAssignability() {
   // @ts-expect-error: Type 'Omit<Example, "required1"> & Partial<Pick<Example, "required1">>' is not assignable to type 'Example'
   example = markedOptionalExample;
   optionalExample = example;
+  optionalExample = markedOptionalExample;
   markedOptionalExample = example;
 
   // it verifies that type `Partial<Type>` is NOT assignable to type `Type`
@@ -69,5 +70,12 @@ function testAssignability() {
     object: Type,
     propertyNames: PropertyName[],
     // @ts-expect-error: Type 'MarkOptional<Type, PropertyName>' is not assignable to type 'Type'
+  ) => object is MarkOptional<Type, PropertyName>;
+
+  // it verifies that type `MarkOptional<Type, PropertyName>` is assignable to type `Partial<Type>`
+
+  let assignabilityCheck3: <Type, PropertyName extends keyof Type>(
+    object: Partial<Type>,
+    propertyNames: PropertyName[],
   ) => object is MarkOptional<Type, PropertyName>;
 }

--- a/test/mark-required.ts
+++ b/test/mark-required.ts
@@ -58,6 +58,8 @@ function testAssignability() {
   example = markedRequiredExample;
   // @ts-expect-error: Type 'Example' is not assignable to type 'Required<Example>'
   requiredExample = example;
+  // @ts-expect-error: Type 'MarkRequired<Example, "optional1">' is not assignable to type 'Required<Example>'
+  requiredExample = markedRequiredExample;
   // @ts-expect-error: Type 'Example' is not assignable to type 'Required<Pick<Example, "optional1">>'
   markedRequiredExample = example;
 
@@ -71,5 +73,20 @@ function testAssignability() {
   let assignabilityCheck2: <Type, PropertyName extends keyof Type>(
     object: Type,
     propertyNames: PropertyName[],
+  ) => object is MarkRequired<Type, PropertyName>;
+
+  // it verifies that type `MarkRequired<Type, PropertyName>` is assignable to type `Partial<Type>`
+
+  let assignabilityCheck3: <Type, PropertyName extends keyof Type>(
+    object: Partial<Type>,
+    propertyNames: PropertyName[],
+  ) => object is MarkRequired<Type, PropertyName>;
+
+  // it verifies that type `MarkRequired<Type, PropertyName>` is NOT assignable to type `Required<Type>`
+
+  let assignabilityCheck4: <Type, PropertyName extends keyof Type>(
+    object: Required<Type>,
+    propertyNames: PropertyName[],
+    // @ts-expect-error: Type 'MarkRequired<Type, PropertyName>' is NOT assignable to type 'Required<Type>'
   ) => object is MarkRequired<Type, PropertyName>;
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [X] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Currently, generic instantiations of `MarkOptional` are not assignable to `Partial`. But I don't see a reason why it shouldn't.

<img width="1715" alt="image" src="https://github.com/user-attachments/assets/0609b720-bb5b-43e0-a243-6b1a4387d5e0">

<br />
<br />

This PR:
1. Refactors the implementation of `MarkOptional` to make it assignable to `Partial`.
2. Adds some more test cases for `MarkReadonly`.