### PR TITLE
Fix: `MarkRequired` and `MarkWritable` types when `Keys` is `any`

### DIFF
--- a/.changeset/orange-cycles-wink.md
+++ b/.changeset/orange-cycles-wink.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `MarkRequired<Type, Keys>` & `MarkWritable<Type, Keys>` types when `Keys` is `any`

--- a/lib/mark-required/index.ts
+++ b/lib/mark-required/index.ts
@@ -1,5 +1,5 @@
 import { Prettify } from "../prettify";
 
 export type MarkRequired<Type, Keys extends keyof Type> = Type extends Type
-  ? Prettify<Type & Required<Pick<Type, Keys>>>
+  ? Prettify<Type & Required<Omit<Type, Exclude<keyof Type, Keys>>>>
   : never;

--- a/lib/mark-writable/index.ts
+++ b/lib/mark-writable/index.ts
@@ -3,5 +3,5 @@ import { WritableKeys } from "../writable-keys";
 import { Prettify } from "../prettify";
 
 export type MarkWritable<Type, Keys extends keyof Type> = Type extends Type
-  ? Prettify<Readonly<Type> & Writable<Pick<Type, (Type extends object ? WritableKeys<Type> : never) | Keys>>>
+  ? Prettify<Readonly<Type> & Writable<Omit<Type, Exclude<keyof Type, WritableKeys<Type & object> | Keys>>>>
   : never;

--- a/test/mark-optional.ts
+++ b/test/mark-optional.ts
@@ -11,6 +11,7 @@ type Example = {
 function testMarkOptional() {
   type cases = [
     Assert<IsExact<MarkOptional<Example, never>, Example>>,
+    Assert<IsExact<MarkOptional<Example, any>, Partial<Example>>>,
     Assert<IsExact<MarkOptional<Example, OptionalKeys<Example>>, Example>>,
     Assert<IsExact<MarkOptional<Example, RequiredKeys<Example>>, Partial<Example>>>,
     Assert<

--- a/test/mark-readonly.ts
+++ b/test/mark-readonly.ts
@@ -15,6 +15,7 @@ function testMarkReadonly() {
 
   type cases = [
     Assert<IsExact<MarkReadonly<Example, never>, Example>>,
+    Assert<IsExact<MarkReadonly<Example, any>, Readonly<Example>>>,
     Assert<IsExact<MarkReadonly<Example, ReadonlyKeys<Example>>, Example>>,
     Assert<IsExact<MarkReadonly<Example, WritableKeys<Example>>, Readonly<Example>>>,
     Assert<IsExact<ReadonlyKeys<ExampleWithReadonlyRequired1>, "readonly1" | "readonly2" | "required1">>,

--- a/test/mark-required.ts
+++ b/test/mark-required.ts
@@ -13,6 +13,7 @@ type Example = {
 function testMarkRequired() {
   type cases = [
     Assert<IsExact<MarkRequired<Example, never>, Example>>,
+    Assert<IsExact<MarkRequired<Example, any>, Required<Example>>>,
     Assert<IsExact<MarkRequired<Example, RequiredKeys<Example>>, Example>>,
     Assert<IsExact<MarkRequired<Example, OptionalKeys<Example>>, Required<Example>>>,
     Assert<

--- a/test/mark-writable.ts
+++ b/test/mark-writable.ts
@@ -15,6 +15,7 @@ function testMarkWritable() {
 
   type cases = [
     Assert<IsExact<MarkWritable<Example, never>, Example>>,
+    Assert<IsExact<MarkWritable<Example, any>, Writable<Example>>>,
     Assert<IsExact<MarkWritable<Example, WritableKeys<Example>>, Example>>,
     Assert<IsExact<MarkWritable<Example, ReadonlyKeys<Example>>, Writable<Example>>>,
     Assert<IsExact<ReadonlyKeys<ExampleWithWritableReadonly1>, "readonly2">>,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
The `MarkRequired` and `MarkWritable` types currently have issues when the second type argument is `any`. This is because their implementation relies on `Pick`, which does not handle `any` correctly.

For eg, `MarkRequired<{ a?: 1; b?: 2 }, any>` currently evaluates to type `{ [x: string]: any; a?: 1; b?: 2 }`, instead it should have simply evaluated to type `{ a: 1; b: 2 }`.

This PR refactors these types to use a combination of `Omit` and `Exclude` instead of `Pick`, ensuring proper functionality with `any`.