### PR TITLE
Fix: `Tail` with optional, readonly and non-tuple arrays

### DIFF
--- a/lib/tail/index.ts
+++ b/lib/tail/index.ts
@@ -1,3 +1,7 @@
 import { AnyArray } from "../any-array";
 
-export type Tail<Type extends AnyArray> = Type extends [any, ...infer Rest] ? Rest : never;
+export type Tail<Type extends AnyArray> = Type extends readonly []
+  ? never
+  : Type extends readonly [any?, ...infer Rest]
+  ? Rest
+  : never;

--- a/test/index.ts
+++ b/test/index.ts
@@ -625,15 +625,29 @@ function testNoop() {
   const callback: (_: number) => void = noop;
 }
 
-function testHeadTail() {
+function testHead() {
   type List1 = [number, string, boolean, "a" | "b"];
 
   type TestHead = Assert<IsExact<Head<List1>, number>>;
   type TestHeadOnEmpty = Assert<IsExact<Head<[]>, never>>;
+}
 
-  type TestTail = Assert<IsExact<Tail<List1>, [string, boolean, "a" | "b"]>>;
-  type TestTailOnEmpty = Assert<IsExact<Tail<[]>, never>>;
-  type TestTailOn1Elem = Assert<IsExact<Tail<[number]>, []>>;
+function testTail() {
+  type cases = [
+    Assert<IsExact<Tail<[]>, never>>,
+    Assert<IsExact<Tail<readonly []>, never>>,
+    Assert<IsExact<Tail<[1, 2, 3 | 4]>, [2, 3 | 4]>>,
+    Assert<IsExact<Tail<readonly [1, 2, 3 | 4]>, [2, 3 | 4]>>,
+    Assert<IsExact<Tail<[1]>, []>>,
+    Assert<IsExact<Tail<[1?]>, []>>,
+    Assert<IsExact<Tail<[1, 2] | [3, 4]>, [2] | [4]>>,
+    Assert<IsExact<Tail<[1?, 2?, 3?]>, [2?, 3?]>>,
+    Assert<IsExact<Tail<[1, 2, ...number[]]>, [2, ...number[]]>>,
+    Assert<IsExact<Tail<number[]>, number[]>>,
+    Assert<IsExact<Tail<readonly number[]>, number[]>>,
+    Assert<IsExact<Tail<any>, unknown[]>>,
+    Assert<IsExact<Tail<never>, never>>,
+  ];
 }
 
 function testExact() {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: related to #000
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I came across [this issue](https://github.com/sindresorhus/type-fest/issues/978) in `type-fest` regarding their implementation of `Tail`, which doesn't work as expected when instantiated with an array of all optional elements. Our implementation of `Tail` also fails in this case; when instantiated with `[1?, 2?, 3?]`, it returns `never` instead of the expected `[2?, 3?]`.
<br>
Additionally, there are two other issues with the current implementation:
1. **Readonly Arrays**: `Tail` incorrectly returns `never` when instantiated with `readonly` arrays.
2. **Non-Tuple Arrays**: When applied to non-tuple arrays (e.g., `string[]`), `Tail` currently returns `never`. I believe it should instead return back the same type, e.g., `Tail<string[]>` should return `string[]`. However, in such scenarios, `type-fest` also returns an empty array, which is kinda equivalent to our version of `never`, though I'm unsure why.

@Beraliv If you think we should continue to return `never` for non-tuple arrays, then the [solution I proposed here](https://github.com/sindresorhus/type-fest/pull/977#issuecomment-2509125871) should work.