### PR TITLE
fix: `Prettify` when instantiated with classes containing private/protected members

### DIFF
--- a/.changeset/curly-poets-battle.md
+++ b/.changeset/curly-poets-battle.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix `Prettify<Type>` type when `Type` is a class with private/protected members

--- a/lib/mark-optional/index.ts
+++ b/lib/mark-optional/index.ts
@@ -2,5 +2,5 @@ import { OptionalKeys } from "../optional-keys";
 import { Prettify } from "../prettify";
 
 export type MarkOptional<Type, Keys extends keyof Type> = Type extends Type
-  ? Prettify<Partial<Type> & Required<Omit<Type, Keys | OptionalKeys<Type>>>>
+  ? Extract<Prettify<Partial<Type> & Required<Omit<Type, Keys | OptionalKeys<Type>>>>, Partial<Type>>
   : never;

--- a/lib/prettify/index.ts
+++ b/lib/prettify/index.ts
@@ -1,8 +1,5 @@
 export type Prettify<Type> = Type extends Function
   ? Type
-  : Extract<
-      {
-        [Key in keyof Type]: Type[Key];
-      },
-      Type
-    >;
+  : {
+      [Key in keyof Type]: Type[Key];
+    };

--- a/test/prettify.ts
+++ b/test/prettify.ts
@@ -20,7 +20,8 @@ function testPrettify() {
 
 function testAssignability() {
   let assignabilityCheck1: <Type>(arg: Type) => arg is Prettify<Type>;
-  // let assignabilityCheck2: <Type>(arg: Prettify<Type>) => arg is Type; // This fails currently, but shouldn't ideally
+  // @ts-expect-error
+  let assignabilityCheck2: <Type>(arg: Prettify<Type>) => arg is Type; // This fails currently, but shouldn't ideally
 }
 
 function testClass() {

--- a/test/prettify.ts
+++ b/test/prettify.ts
@@ -17,3 +17,19 @@ function testPrettify() {
     Assert<IsExact<Prettify<() => void>, () => void>>,
   ];
 }
+
+function testAssignability() {
+  let assignabilityCheck1: <Type>(arg: Type) => arg is Prettify<Type>;
+  // let assignabilityCheck2: <Type>(arg: Prettify<Type>) => arg is Type; // This fails currently, but shouldn't ideally
+}
+
+function testClass() {
+  class TestClass {
+    private _a: number = Date.now();
+    protected _b: Date = new Date();
+    c?: string;
+    d: boolean = true;
+  }
+
+  type cases = [Assert<IsExact<Prettify<TestClass>, { c?: string; d: boolean }>>];
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to #439 
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR implements the changes mentioned in https://github.com/ts-essentials/ts-essentials/issues/439#issuecomment-3195857140.