### PR TITLE
fix: `UnionKeys` assignability

### DIFF
--- a/.changeset/tender-lamps-join.md
+++ b/.changeset/tender-lamps-join.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix assignability for `UnionKeys`

--- a/.changeset/twelve-suns-fly.md
+++ b/.changeset/twelve-suns-fly.md
@@ -1,0 +1,5 @@
+---
+"ts-essentials": patch
+---
+
+Fix assignability for `UnionToIntersection`

--- a/lib/union-keys/index.ts
+++ b/lib/union-keys/index.ts
@@ -1,6 +1,6 @@
 import { UnionToIntersection } from "../union-to-intersection";
 
-// Adopted a hack from type-fest - https://github.com/sindresorhus/type-fest/pull/1009
+// Adopted a workaround by som-sm from type-fest - https://github.com/sindresorhus/type-fest/pull/1009
 export type UnionKeys<UnionType> = keyof UnionToIntersection<
   UnionType extends UnionType ? Record<keyof UnionType, never> : never
 >;

--- a/lib/union-keys/index.ts
+++ b/lib/union-keys/index.ts
@@ -1,1 +1,6 @@
-export type UnionKeys<UnionType> = UnionType extends UnionType ? keyof UnionType : never;
+import { UnionToIntersection } from "../union-to-intersection";
+
+// Adopted a hack from type-fest - https://github.com/sindresorhus/type-fest/pull/1009
+export type UnionKeys<UnionType> = keyof UnionToIntersection<
+  UnionType extends UnionType ? Record<keyof UnionType, never> : never
+>;

--- a/lib/union-to-intersection/index.ts
+++ b/lib/union-to-intersection/index.ts
@@ -1,5 +1,5 @@
 export type UnionToIntersection<Union> = (Union extends any ? (arg: Union) => void : never) extends (
   arg: infer Intersection,
 ) => void
-  ? Intersection
+  ? Union & Intersection
   : never;

--- a/lib/union-to-intersection/index.ts
+++ b/lib/union-to-intersection/index.ts
@@ -1,5 +1,6 @@
 export type UnionToIntersection<Union> = (Union extends any ? (arg: Union) => void : never) extends (
   arg: infer Intersection,
 ) => void
-  ? Union & Intersection
+  ? // Order matters here - do not swap Intersection and Union
+    Intersection & Union
   : never;

--- a/lib/union-to-tuple.ts
+++ b/lib/union-to-tuple.ts
@@ -1,8 +1,14 @@
-import { UnionToIntersection } from "./union-to-intersection";
+// Don't use `UnionToIntersection` because assignable version returns `never` in
+// `LastOfUnion` for any union
+type NonAssignableUnionToIntersection<Union> = (Union extends any ? (arg: Union) => void : never) extends (
+  arg: infer Intersection,
+) => void
+  ? Intersection
+  : never;
 
-type LastOfUnion<UnionType> = UnionToIntersection<
-  UnionType extends unknown ? (arg: UnionType) => unknown : never
-> extends (arg: infer LastUnionElement) => unknown
+type LastOfUnion<UnionType> = NonAssignableUnionToIntersection<
+  UnionType extends unknown ? (args: UnionType) => void : never
+> extends (args: infer LastUnionElement) => void
   ? LastUnionElement
   : never;
 

--- a/lib/union-to-tuple.ts
+++ b/lib/union-to-tuple.ts
@@ -1,14 +1,8 @@
-// Don't use `UnionToIntersection` because assignable version returns `never` in
-// `LastOfUnion` for any union
-type NonAssignableUnionToIntersection<Union> = (Union extends any ? (arg: Union) => void : never) extends (
-  arg: infer Intersection,
-) => void
-  ? Intersection
-  : never;
+import { UnionToIntersection } from "./union-to-intersection";
 
-type LastOfUnion<UnionType> = NonAssignableUnionToIntersection<
-  UnionType extends unknown ? (args: UnionType) => void : never
-> extends (args: infer LastUnionElement) => void
+type LastOfUnion<UnionType> = UnionToIntersection<
+  UnionType extends unknown ? (arg: UnionType) => unknown : never
+> extends (arg: infer LastUnionElement) => unknown
   ? LastUnionElement
   : never;
 

--- a/test/deep-mark-optional.ts
+++ b/test/deep-mark-optional.ts
@@ -1,5 +1,5 @@
 import { AssertTrue as Assert, IsExact } from "conditional-type-checks";
-import { DeepRequired, DeepMarkOptional, Paths, DeepNullable, DeepPartial } from "../lib";
+import { DeepMarkOptional, Paths, DeepNullable, DeepPartial } from "../lib";
 
 function testWithDeepRequired() {
   type Teacher = { address: { postcode: string; city: string } };

--- a/test/union-keys.ts
+++ b/test/union-keys.ts
@@ -1,13 +1,29 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
 import { UnionKeys } from "../lib";
 
+function testAssignability() {
+  // @ts-expect-error: `UnionKeys<Type>` is NOT assignable to `keyof Type`
+  let test1: <Type>(object: Type, propertyNames: keyof Type) => propertyNames is UnionKeys<Type>;
+
+  // `keyof Type` is assignable to `UnionKeys<Type>`
+  let test2: <Type>(object: Type, propertyNames: UnionKeys<Type>) => propertyNames is keyof Type;
+
+  // `UnionKeys<Type>` is assignable to `PropertyKey`
+  let test3: <Type>(object: Type, propertyNames: PropertyKey) => propertyNames is UnionKeys<Type>;
+
+  // @ts-expect-error: `PropertyKey` is NOT assignable to `UnionKeys<Type>`
+  let test4: <Type>(object: Type, propertyNames: UnionKeys<Type>) => propertyNames is PropertyKey;
+}
+
 function testUnionKeys() {
   type UnionOf1 = { type: "start"; ms: number };
   type UnionOf2 = UnionOf1 | { type: "stop"; reason: string };
   type UnionOf3 = UnionOf2 | { type: "report"; crashed: boolean };
 
-  type assertion = [
-    AssertTrue<IsExact<UnionKeys<never>, never>>,
+  type a = UnionKeys<never>;
+
+  type assertions = [
+    AssertTrue<IsExact<UnionKeys<never>, PropertyKey>>,
     AssertTrue<IsExact<UnionKeys<UnionOf1>, "type" | "ms">>,
     AssertTrue<IsExact<UnionKeys<UnionOf2>, "type" | "ms" | "reason">>,
     AssertTrue<IsExact<UnionKeys<UnionOf3>, "type" | "ms" | "reason" | "crashed">>,

--- a/test/union-keys.ts
+++ b/test/union-keys.ts
@@ -20,8 +20,6 @@ function testUnionKeys() {
   type UnionOf2 = UnionOf1 | { type: "stop"; reason: string };
   type UnionOf3 = UnionOf2 | { type: "report"; crashed: boolean };
 
-  type a = UnionKeys<never>;
-
   type assertions = [
     AssertTrue<IsExact<UnionKeys<never>, PropertyKey>>,
     AssertTrue<IsExact<UnionKeys<UnionOf1>, "type" | "ms">>,

--- a/test/union-to-intersection.ts
+++ b/test/union-to-intersection.ts
@@ -2,17 +2,17 @@ import { AssertTrue, IsExact } from "conditional-type-checks";
 import { UnionToIntersection } from "../lib";
 
 function testAssignability() {
-  // `UnionToIntersection<T>` is assignable to `T`
-  let test1: <T>(t: T) => t is UnionToIntersection<T>;
+  // `UnionToIntersection<Type>` is assignable to `Type`
+  let test1: <Type>(t: Type) => t is UnionToIntersection<Type>;
 
-  // @ts-expect-error: `T` is NOT assignable to `UnionToIntersection<T>`
-  let test2: <T>(t: UnionToIntersection<T>) => t is T;
+  // @ts-expect-error: `Type` is NOT assignable to `UnionToIntersection<Type>`
+  let test2: <Type>(t: UnionToIntersection<Type>) => t is Type;
 
-  // `UnionToIntersection<T | U>` is assignable to `T | U`
-  let test3: <T, U>(t: T | U) => t is UnionToIntersection<T | U>;
+  // `UnionToIntersection<Type1 | Type2>` is assignable to `Type1 | Type2`
+  let test3: <Type1, Type2>(t: Type1 | Type2) => t is UnionToIntersection<Type1 | Type2>;
 
-  // @ts-expect-error: `T | U` is NOT assignable to `UnionToIntersection<T | U>`
-  let test4: <T, U>(t: UnionToIntersection<T | U>) => t is T | U;
+  // @ts-expect-error: `Type1 | Type2` is NOT assignable to `UnionToIntersection<Type1 | Type2>`
+  let test4: <Type1, Type2>(t: UnionToIntersection<Type1 | Type2>) => t is Type1 | Type2;
 }
 
 function testUnionToIntersection() {

--- a/test/union-to-intersection.ts
+++ b/test/union-to-intersection.ts
@@ -1,6 +1,20 @@
 import { AssertTrue, IsExact } from "conditional-type-checks";
 import { UnionToIntersection } from "../lib";
 
+function testAssignability() {
+  // `UnionToIntersection<T>` is assignable to `T`
+  let test1: <T>(t: T) => t is UnionToIntersection<T>;
+
+  // @ts-expect-error: `T` is NOT assignable to `UnionToIntersection<T>`
+  let test2: <T>(t: UnionToIntersection<T>) => t is T;
+
+  // `UnionToIntersection<T | U>` is assignable to `T | U`
+  let test3: <T, U>(t: T | U) => t is UnionToIntersection<T | U>;
+
+  // @ts-expect-error: `T | U` is NOT assignable to `UnionToIntersection<T | U>`
+  let test4: <T, U>(t: UnionToIntersection<T | U>) => t is T | U;
+}
+
 function testUnionToIntersection() {
   type WithName = { name: string };
   type WithAge = { age: number };

--- a/test/union-to-intersection.ts
+++ b/test/union-to-intersection.ts
@@ -1,0 +1,16 @@
+import { AssertTrue, IsExact } from "conditional-type-checks";
+import { UnionToIntersection } from "../lib";
+
+function testUnionToIntersection() {
+  type WithName = { name: string };
+  type WithAge = { age: number };
+  type WithGender = { gender: string };
+
+  type assertions = [
+    AssertTrue<IsExact<UnionToIntersection<WithName>, { name: string }>>,
+    AssertTrue<IsExact<UnionToIntersection<WithName | WithAge>, { age: number; name: string }>>,
+    AssertTrue<
+      IsExact<UnionToIntersection<WithName | WithAge | WithGender>, { age: number; gender: string; name: string }>
+    >,
+  ];
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to ts-essentials! 🧡
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: related to #451
- [x] Steps in [Contributing](https://github.com/ts-essentials/ts-essentials/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

1. Fixed assignability for `UnionKeys` and `UnionToIntersection`
2. Added unit tests for `UnionKeys` and `UnionToIntersection` assignability
3. Referenced the hack from https://github.com/sindresorhus/type-fest/pull/1009
4. Used non-assignable version of `UnionToIntersection` in `UnionToTuple`

## Credit

@som-sm thank you a lot for flagging the issue in https://github.com/ts-essentials/ts-essentials/pull/449/files#r2404512712 and coming up with the workaround in https://github.com/sindresorhus/type-fest/pull/1009 🧡